### PR TITLE
feat: SQS通知 + アプリ内/Web Push通知 + テスト全面追加

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -23,6 +23,7 @@ dependencyManagement {
     imports {
         mavenBom("io.awspring.cloud:spring-cloud-aws-dependencies:${property("springCloudAwsVersion")}")
         mavenBom("software.amazon.awssdk:bom:2.29.50")
+        mavenBom("org.testcontainers:testcontainers-bom:1.21.1")
     }
 }
 
@@ -49,11 +50,24 @@ dependencies {
     implementation("software.amazon.awssdk:s3")
     implementation("software.amazon.awssdk:sts")
 
+    // Web Push
+    implementation("nl.martijndwars:web-push:5.1.1")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.80")
+
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.springframework.security:spring-security-test")
+    // Docker 28+ requires API v1.40+, docker-java 3.4.x defaults to v1.32
+    testImplementation("com.github.docker-java:docker-java-api") { version { strictly("3.5.1") } }
+    testImplementation("com.github.docker-java:docker-java-transport-zerodep") { version { strictly("3.5.1") } }
+    testImplementation("com.github.docker-java:docker-java-transport") { version { strictly("3.5.1") } }
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    environment("DOCKER_API_VERSION", "1.43")
 }

--- a/api/src/main/java/com/example/chat/config/S3Config.java
+++ b/api/src/main/java/com/example/chat/config/S3Config.java
@@ -2,11 +2,13 @@ package com.example.chat.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
+@Profile("!test")
 public class S3Config {
 
     @Bean

--- a/api/src/main/java/com/example/chat/config/WebPushConfig.java
+++ b/api/src/main/java/com/example/chat/config/WebPushConfig.java
@@ -1,0 +1,28 @@
+package com.example.chat.config;
+
+import nl.martijndwars.webpush.PushService;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.GeneralSecurityException;
+import java.security.Security;
+
+@Configuration
+public class WebPushConfig {
+
+    @Bean
+    @ConditionalOnExpression("!'${app.webpush.vapid-public-key:}'.isEmpty()")
+    public PushService pushService(
+            @Value("${app.webpush.vapid-public-key}") String publicKey,
+            @Value("${app.webpush.vapid-private-key}") String privateKey,
+            @Value("${app.webpush.vapid-subject:mailto:admin@example.com}") String subject)
+            throws GeneralSecurityException {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        return new PushService(publicKey, privateKey, subject);
+    }
+}

--- a/api/src/main/java/com/example/chat/controller/NotificationController.java
+++ b/api/src/main/java/com/example/chat/controller/NotificationController.java
@@ -1,0 +1,39 @@
+package com.example.chat.controller;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public NotificationController(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @GetMapping("/unread")
+    public Map<String, Long> getUnreadCounts(Principal principal) {
+        String key = "unread:" + principal.getName();
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+        var result = new HashMap<String, Long>();
+        entries.forEach((roomId, count) ->
+                result.put(roomId.toString(), Long.parseLong(count.toString()))
+        );
+        return result;
+    }
+
+    @DeleteMapping("/unread/{roomId}")
+    public ResponseEntity<Void> clearUnread(@PathVariable UUID roomId, Principal principal) {
+        String key = "unread:" + principal.getName();
+        redisTemplate.opsForHash().delete(key, roomId.toString());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/api/src/main/java/com/example/chat/controller/PushSubscriptionController.java
+++ b/api/src/main/java/com/example/chat/controller/PushSubscriptionController.java
@@ -1,0 +1,60 @@
+package com.example.chat.controller;
+
+import com.example.chat.model.dto.PushSubscriptionRequest;
+import com.example.chat.model.entity.PushSubscription;
+import com.example.chat.repository.PushSubscriptionRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/push")
+public class PushSubscriptionController {
+
+    private final PushSubscriptionRepository pushSubscriptionRepository;
+    private final String vapidPublicKey;
+
+    public PushSubscriptionController(
+            PushSubscriptionRepository pushSubscriptionRepository,
+            @Value("${app.webpush.vapid-public-key:}") String vapidPublicKey) {
+        this.pushSubscriptionRepository = pushSubscriptionRepository;
+        this.vapidPublicKey = vapidPublicKey;
+    }
+
+    @GetMapping("/vapid-key")
+    public Map<String, String> getVapidKey() {
+        return Map.of("publicKey", vapidPublicKey);
+    }
+
+    @PostMapping("/subscribe")
+    @Transactional
+    public ResponseEntity<Void> subscribe(@RequestBody PushSubscriptionRequest request, Principal principal) {
+        var existing = pushSubscriptionRepository.findByEndpoint(request.endpoint());
+        if (existing.isPresent()) {
+            return ResponseEntity.ok().build();
+        }
+
+        var sub = new PushSubscription();
+        sub.setUserId(principal.getName());
+        sub.setEndpoint(request.endpoint());
+        sub.setP256dh(request.p256dh());
+        sub.setAuth(request.auth());
+        pushSubscriptionRepository.save(sub);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/unsubscribe")
+    @Transactional
+    public ResponseEntity<Void> unsubscribe(@RequestBody Map<String, String> body, Principal principal) {
+        String endpoint = body.get("endpoint");
+        if (endpoint != null) {
+            pushSubscriptionRepository.deleteByEndpoint(endpoint);
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/api/src/main/java/com/example/chat/listener/LocalNotificationListener.java
+++ b/api/src/main/java/com/example/chat/listener/LocalNotificationListener.java
@@ -3,28 +3,29 @@ package com.example.chat.listener;
 import com.example.chat.model.dto.ChatNotificationEvent;
 import com.example.chat.service.NotificationService;
 import com.example.chat.service.WebPushService;
-import io.awspring.cloud.sqs.annotation.SqsListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-public class SqsMessageListener {
+@Profile("local")
+public class LocalNotificationListener {
 
-    private static final Logger log = LoggerFactory.getLogger(SqsMessageListener.class);
+    private static final Logger log = LoggerFactory.getLogger(LocalNotificationListener.class);
 
     private final NotificationService notificationService;
     private final WebPushService webPushService;
 
-    public SqsMessageListener(NotificationService notificationService, WebPushService webPushService) {
+    public LocalNotificationListener(NotificationService notificationService, WebPushService webPushService) {
         this.notificationService = notificationService;
         this.webPushService = webPushService;
     }
 
-    @SqsListener("${app.sqs.chat-message-queue}")
-    public void onMessage(ChatNotificationEvent event) {
-        log.info("Processing notification: messageId={}, roomId={}, senderId={}",
-                event.messageId(), event.roomId(), event.senderId());
+    @EventListener
+    public void onChatNotification(ChatNotificationEvent event) {
+        log.info("Local notification event: messageId={}, roomId={}", event.messageId(), event.roomId());
         notificationService.notifyRoomMembers(event);
         webPushService.sendPushToMembers(event);
     }

--- a/api/src/main/java/com/example/chat/model/dto/ChatNotificationEvent.java
+++ b/api/src/main/java/com/example/chat/model/dto/ChatNotificationEvent.java
@@ -1,0 +1,15 @@
+package com.example.chat.model.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record ChatNotificationEvent(
+        UUID messageId,
+        UUID roomId,
+        String senderId,
+        String senderName,
+        String content,
+        String messageType,
+        Instant createdAt
+) {
+}

--- a/api/src/main/java/com/example/chat/model/dto/NotificationPayload.java
+++ b/api/src/main/java/com/example/chat/model/dto/NotificationPayload.java
@@ -1,0 +1,14 @@
+package com.example.chat.model.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationPayload(
+        UUID roomId,
+        UUID messageId,
+        String senderName,
+        String contentPreview,
+        String messageType,
+        Instant createdAt
+) {
+}

--- a/api/src/main/java/com/example/chat/model/dto/PushSubscriptionRequest.java
+++ b/api/src/main/java/com/example/chat/model/dto/PushSubscriptionRequest.java
@@ -1,0 +1,8 @@
+package com.example.chat.model.dto;
+
+public record PushSubscriptionRequest(
+        String endpoint,
+        String p256dh,
+        String auth
+) {
+}

--- a/api/src/main/java/com/example/chat/model/entity/PushSubscription.java
+++ b/api/src/main/java/com/example/chat/model/entity/PushSubscription.java
@@ -1,0 +1,47 @@
+package com.example.chat.model.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "push_subscriptions")
+public class PushSubscription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(nullable = false, unique = true)
+    private String endpoint;
+
+    @Column(nullable = false)
+    private String p256dh;
+
+    @Column(nullable = false)
+    private String auth;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+    }
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+    public String getEndpoint() { return endpoint; }
+    public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+    public String getP256dh() { return p256dh; }
+    public void setP256dh(String p256dh) { this.p256dh = p256dh; }
+    public String getAuth() { return auth; }
+    public void setAuth(String auth) { this.auth = auth; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/api/src/main/java/com/example/chat/repository/PushSubscriptionRepository.java
+++ b/api/src/main/java/com/example/chat/repository/PushSubscriptionRepository.java
@@ -1,0 +1,17 @@
+package com.example.chat.repository;
+
+import com.example.chat.model.entity.PushSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PushSubscriptionRepository extends JpaRepository<PushSubscription, UUID> {
+
+    List<PushSubscription> findByUserId(String userId);
+
+    Optional<PushSubscription> findByEndpoint(String endpoint);
+
+    void deleteByEndpoint(String endpoint);
+}

--- a/api/src/main/java/com/example/chat/service/ChatService.java
+++ b/api/src/main/java/com/example/chat/service/ChatService.java
@@ -15,10 +15,13 @@ public class ChatService {
 
     private final ChatMessageRepository chatMessageRepository;
     private final SearchService searchService;
+    private final SqsNotificationService sqsNotificationService;
 
-    public ChatService(ChatMessageRepository chatMessageRepository, SearchService searchService) {
+    public ChatService(ChatMessageRepository chatMessageRepository, SearchService searchService,
+                       SqsNotificationService sqsNotificationService) {
         this.chatMessageRepository = chatMessageRepository;
         this.searchService = searchService;
+        this.sqsNotificationService = sqsNotificationService;
     }
 
     @Transactional
@@ -35,6 +38,11 @@ public class ChatService {
             searchService.indexMessage(saved);
         } catch (Exception e) {
             // ES障害時もメッセージ送信は成功させる
+        }
+        try {
+            sqsNotificationService.sendNotification(saved);
+        } catch (Exception e) {
+            // SQS障害時もメッセージ送信は成功させる
         }
         return saved;
     }

--- a/api/src/main/java/com/example/chat/service/NotificationService.java
+++ b/api/src/main/java/com/example/chat/service/NotificationService.java
@@ -1,0 +1,59 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.model.dto.NotificationPayload;
+import com.example.chat.repository.RoomMemberRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationService.class);
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final RoomMemberRepository roomMemberRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public NotificationService(SimpMessagingTemplate messagingTemplate,
+                               RoomMemberRepository roomMemberRepository,
+                               RedisTemplate<String, String> redisTemplate) {
+        this.messagingTemplate = messagingTemplate;
+        this.roomMemberRepository = roomMemberRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void notifyRoomMembers(ChatNotificationEvent event) {
+        var members = roomMemberRepository.findByRoomId(event.roomId());
+        var payload = new NotificationPayload(
+                event.roomId(),
+                event.messageId(),
+                event.senderName(),
+                truncate(event.content(), 100),
+                event.messageType(),
+                event.createdAt()
+        );
+
+        for (var member : members) {
+            if (member.getUserId().equals(event.senderId())) continue;
+
+            messagingTemplate.convertAndSendToUser(
+                    member.getUserId(), "/queue/notifications", payload
+            );
+            redisTemplate.opsForHash().increment(
+                    "unread:" + member.getUserId(), event.roomId().toString(), 1
+            );
+        }
+
+        log.info("Notified {} members for message {} in room {}",
+                members.size() - 1, event.messageId(), event.roomId());
+    }
+
+    private String truncate(String text, int maxLength) {
+        if (text == null) return "";
+        return text.length() <= maxLength ? text : text.substring(0, maxLength) + "...";
+    }
+}

--- a/api/src/main/java/com/example/chat/service/SqsNotificationService.java
+++ b/api/src/main/java/com/example/chat/service/SqsNotificationService.java
@@ -1,0 +1,51 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.model.entity.ChatMessage;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SqsNotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(SqsNotificationService.class);
+
+    private final SqsTemplate sqsTemplate;
+    private final String queueName;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public SqsNotificationService(
+            ObjectProvider<SqsTemplate> sqsTemplateProvider,
+            @Value("${app.sqs.chat-message-queue:}") String queueName,
+            ApplicationEventPublisher eventPublisher) {
+        this.sqsTemplate = sqsTemplateProvider.getIfAvailable();
+        this.queueName = queueName;
+        this.eventPublisher = eventPublisher;
+    }
+
+    public void sendNotification(ChatMessage message) {
+        var event = new ChatNotificationEvent(
+                message.getId(),
+                message.getRoomId(),
+                message.getSenderId(),
+                message.getSenderName(),
+                message.getContent(),
+                message.getMessageType(),
+                message.getCreatedAt()
+        );
+
+        if (sqsTemplate == null || queueName.isBlank()) {
+            log.debug("SQS is not configured, publishing local event for message {}", message.getId());
+            eventPublisher.publishEvent(event);
+            return;
+        }
+
+        sqsTemplate.send(to -> to.queue(queueName).payload(event));
+        log.info("Sent notification to SQS for message {} in room {}", message.getId(), message.getRoomId());
+    }
+}

--- a/api/src/main/java/com/example/chat/service/WebPushService.java
+++ b/api/src/main/java/com/example/chat/service/WebPushService.java
@@ -1,0 +1,89 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.model.entity.PushSubscription;
+import com.example.chat.repository.PushSubscriptionRepository;
+import com.example.chat.repository.RoomMemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
+import org.apache.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+public class WebPushService {
+
+    private static final Logger log = LoggerFactory.getLogger(WebPushService.class);
+
+    private final PushService pushService;
+    private final PushSubscriptionRepository pushSubscriptionRepository;
+    private final RoomMemberRepository roomMemberRepository;
+    private final ObjectMapper objectMapper;
+
+    public WebPushService(ObjectProvider<PushService> pushServiceProvider,
+                          PushSubscriptionRepository pushSubscriptionRepository,
+                          RoomMemberRepository roomMemberRepository,
+                          ObjectMapper objectMapper) {
+        this.pushService = pushServiceProvider.getIfAvailable();
+        this.pushSubscriptionRepository = pushSubscriptionRepository;
+        this.roomMemberRepository = roomMemberRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    public void sendPushToMembers(ChatNotificationEvent event) {
+        if (pushService == null) {
+            log.debug("Web Push is not configured, skipping push for message {}", event.messageId());
+            return;
+        }
+
+        var members = roomMemberRepository.findByRoomId(event.roomId());
+        for (var member : members) {
+            if (member.getUserId().equals(event.senderId())) continue;
+
+            var subscriptions = pushSubscriptionRepository.findByUserId(member.getUserId());
+            for (var sub : subscriptions) {
+                sendPush(sub, event);
+            }
+        }
+    }
+
+    private void sendPush(PushSubscription sub, ChatNotificationEvent event) {
+        try {
+            var payload = objectMapper.writeValueAsString(Map.of(
+                    "roomId", event.roomId().toString(),
+                    "senderName", event.senderName(),
+                    "contentPreview", truncate(event.content(), 100),
+                    "messageType", event.messageType()
+            ));
+
+            var notification = new Notification(
+                    sub.getEndpoint(),
+                    sub.getP256dh(),
+                    sub.getAuth(),
+                    payload
+            );
+
+            HttpResponse response = pushService.send(notification);
+            int statusCode = response.getStatusLine().getStatusCode();
+
+            if (statusCode == 410 || statusCode == 404) {
+                log.info("Push subscription expired, removing: {}", sub.getEndpoint());
+                pushSubscriptionRepository.delete(sub);
+            } else if (statusCode >= 400) {
+                log.warn("Push failed with status {} for endpoint {}", statusCode, sub.getEndpoint());
+            }
+        } catch (Exception e) {
+            log.warn("Push failed for endpoint {}: {}", sub.getEndpoint(), e.getMessage());
+        }
+    }
+
+    private String truncate(String text, int maxLength) {
+        if (text == null) return "";
+        return text.length() <= maxLength ? text : text.substring(0, maxLength) + "...";
+    }
+}

--- a/api/src/main/resources/application-local.yaml
+++ b/api/src/main/resources/application-local.yaml
@@ -23,3 +23,4 @@ app:
     bucket: local-chat-uploads
   sqs:
     queue-url: ""
+    chat-message-queue: ""

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -41,9 +41,14 @@ app:
     bucket: ${S3_BUCKET:chat-uploads}
   sqs:
     queue-url: ${SQS_QUEUE_URL:}
+    chat-message-queue: ${SQS_CHAT_MESSAGE_QUEUE:chat-messages}
   cognito:
     user-pool-id: ${COGNITO_USER_POOL_ID:}
     client-id: ${COGNITO_CLIENT_ID:}
+  webpush:
+    vapid-public-key: ${VAPID_PUBLIC_KEY:}
+    vapid-private-key: ${VAPID_PRIVATE_KEY:}
+    vapid-subject: ${VAPID_SUBJECT:mailto:admin@example.com}
 
 management:
   endpoints:

--- a/api/src/main/resources/db/migration/V6__create_push_subscriptions.sql
+++ b/api/src/main/resources/db/migration/V6__create_push_subscriptions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE push_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id VARCHAR(255) NOT NULL REFERENCES users(id),
+    endpoint TEXT NOT NULL UNIQUE,
+    p256dh TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_push_subscriptions_user_id ON push_subscriptions(user_id);

--- a/api/src/test/java/com/example/chat/integration/BaseIntegrationTest.java
+++ b/api/src/test/java/com/example/chat/integration/BaseIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.example.chat.integration;
+
+import com.example.chat.repository.ChatMessageSearchRepository;
+import com.example.chat.service.SearchService;
+import com.example.chat.service.SqsNotificationService;
+import com.example.chat.service.WebPushService;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public abstract class BaseIntegrationTest {
+
+    static {
+        System.setProperty("api.version", "1.43");
+    }
+
+    static final PostgreSQLContainer<?> postgres;
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> redis;
+
+    static {
+        postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+                .withDatabaseName("chat_test")
+                .withUsername("test")
+                .withPassword("test");
+        postgres.start();
+
+        redis = new GenericContainer<>("redis:7-alpine")
+                .withExposedPorts(6379);
+        redis.start();
+    }
+
+    @MockitoBean
+    protected JwtDecoder jwtDecoder;
+
+    @MockitoBean
+    protected SearchService searchService;
+
+    @MockitoBean
+    protected SqsNotificationService sqsNotificationService;
+
+    @MockitoBean
+    protected WebPushService webPushService;
+
+    @MockitoBean
+    protected ChatMessageSearchRepository chatMessageSearchRepository;
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+}

--- a/api/src/test/java/com/example/chat/integration/BaseIntegrationTest.java
+++ b/api/src/test/java/com/example/chat/integration/BaseIntegrationTest.java
@@ -54,6 +54,12 @@ public abstract class BaseIntegrationTest {
     @MockitoBean
     protected ChatMessageSearchRepository chatMessageSearchRepository;
 
+    @MockitoBean
+    protected software.amazon.awssdk.services.s3.presigner.S3Presigner s3Presigner;
+
+    @MockitoBean
+    protected software.amazon.awssdk.services.s3.S3Client s3Client;
+
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.datasource.url", postgres::getJdbcUrl);

--- a/api/src/test/java/com/example/chat/integration/FriendIntegrationTest.java
+++ b/api/src/test/java/com/example/chat/integration/FriendIntegrationTest.java
@@ -1,0 +1,148 @@
+package com.example.chat.integration;
+
+import com.example.chat.model.entity.User;
+import com.example.chat.repository.FriendshipRepository;
+import com.example.chat.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class FriendIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FriendshipRepository friendshipRepository;
+
+    private User userA;
+    private User userB;
+
+    @BeforeEach
+    void setUp() {
+        friendshipRepository.deleteAll();
+        userRepository.deleteAll();
+
+        userA = new User();
+        userA.setId("user-a");
+        userA.setEmail("alice@example.com");
+        userA.setDisplayName("Alice");
+        userRepository.save(userA);
+
+        userB = new User();
+        userB.setId("user-b");
+        userB.setEmail("bob@example.com");
+        userB.setDisplayName("Bob");
+        userRepository.save(userB);
+    }
+
+    @Test
+    void sendFriendRequest_returnsCreated() throws Exception {
+        mockMvc.perform(post("/api/friends/{userId}/request", userB.getId())
+                        .with(jwt().jwt(j -> j.subject(userA.getId()))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.userId").value(userA.getId()))
+                .andExpect(jsonPath("$.friendId").value(userB.getId()))
+                .andExpect(jsonPath("$.status").value("PENDING"));
+    }
+
+    @Test
+    void acceptFriendRequest_updatesFriendshipStatus() throws Exception {
+        // user-a sends request to user-b
+        mockMvc.perform(post("/api/friends/{userId}/request", userB.getId())
+                        .with(jwt().jwt(j -> j.subject(userA.getId()))))
+                .andExpect(status().isCreated());
+
+        // user-b accepts
+        mockMvc.perform(post("/api/friends/{userId}/accept", userA.getId())
+                        .with(jwt().jwt(j -> j.subject(userB.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACCEPTED"));
+    }
+
+    @Test
+    void listFriends_returnsOnlyAcceptedFriends() throws Exception {
+        // Create and accept a friendship
+        mockMvc.perform(post("/api/friends/{userId}/request", userB.getId())
+                        .with(jwt().jwt(j -> j.subject(userA.getId()))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/friends/{userId}/accept", userA.getId())
+                        .with(jwt().jwt(j -> j.subject(userB.getId()))))
+                .andExpect(status().isOk());
+
+        // Create a third user with a pending request
+        var userC = new User();
+        userC.setId("user-c");
+        userC.setEmail("charlie@example.com");
+        userC.setDisplayName("Charlie");
+        userRepository.save(userC);
+
+        mockMvc.perform(post("/api/friends/{userId}/request", userA.getId())
+                        .with(jwt().jwt(j -> j.subject(userC.getId()))))
+                .andExpect(status().isCreated());
+
+        // List friends for user-a: should only contain user-b (accepted), not user-c (pending)
+        mockMvc.perform(get("/api/friends")
+                        .with(jwt().jwt(j -> j.subject(userA.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(userB.getId()));
+    }
+
+    @Test
+    void listPendingRequests_returnsPendingRequests() throws Exception {
+        // user-a sends request to user-b
+        mockMvc.perform(post("/api/friends/{userId}/request", userB.getId())
+                        .with(jwt().jwt(j -> j.subject(userA.getId()))))
+                .andExpect(status().isCreated());
+
+        // user-b checks pending requests
+        mockMvc.perform(get("/api/friends/requests")
+                        .with(jwt().jwt(j -> j.subject(userB.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].userId").value(userA.getId()))
+                .andExpect(jsonPath("$[0].displayName").value("Alice"));
+    }
+
+    @Test
+    void removeFriend_deletesFriendship() throws Exception {
+        // Create and accept friendship
+        mockMvc.perform(post("/api/friends/{userId}/request", userB.getId())
+                        .with(jwt().jwt(j -> j.subject(userA.getId()))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/friends/{userId}/accept", userA.getId())
+                        .with(jwt().jwt(j -> j.subject(userB.getId()))))
+                .andExpect(status().isOk());
+
+        // Remove friend
+        mockMvc.perform(delete("/api/friends/{userId}", userB.getId())
+                        .with(jwt().jwt(j -> j.subject(userA.getId()))))
+                .andExpect(status().isNoContent());
+
+        // Verify friend list is now empty
+        mockMvc.perform(get("/api/friends")
+                        .with(jwt().jwt(j -> j.subject(userA.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void sendFriendRequest_toSelf_throwsException() {
+        assertThrows(Exception.class, () ->
+                mockMvc.perform(post("/api/friends/{userId}/request", userA.getId())
+                        .with(jwt().jwt(j -> j.subject(userA.getId())))));
+    }
+}

--- a/api/src/test/java/com/example/chat/integration/NotificationIntegrationTest.java
+++ b/api/src/test/java/com/example/chat/integration/NotificationIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.example.chat.integration;
+
+import com.example.chat.model.entity.User;
+import com.example.chat.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class NotificationIntegrationTest extends BaseIntegrationTest {
+
+    private static final String USER_ID = "test-user-1";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        // Clean up Redis
+        String key = "unread:" + USER_ID;
+        redisTemplate.delete(key);
+
+        // Ensure user exists in DB
+        if (userRepository.findById(USER_ID).isEmpty()) {
+            User user = new User();
+            user.setId(USER_ID);
+            user.setEmail("test@example.com");
+            user.setDisplayName("Test User");
+            userRepository.save(user);
+        }
+    }
+
+    @Test
+    void getUnreadCounts_whenNoData_returnsEmptyMap() throws Exception {
+        mockMvc.perform(get("/api/notifications/unread")
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{}"));
+    }
+
+    @Test
+    void getUnreadCounts_whenDataExists_returnsCorrectCounts() throws Exception {
+        String roomId1 = UUID.randomUUID().toString();
+        String roomId2 = UUID.randomUUID().toString();
+        String key = "unread:" + USER_ID;
+
+        redisTemplate.opsForHash().put(key, roomId1, "5");
+        redisTemplate.opsForHash().put(key, roomId2, "3");
+
+        mockMvc.perform(get("/api/notifications/unread")
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$." + roomId1).value(5))
+                .andExpect(jsonPath("$." + roomId2).value(3));
+    }
+
+    @Test
+    void clearUnread_removesCountForRoom() throws Exception {
+        UUID roomId = UUID.randomUUID();
+        String key = "unread:" + USER_ID;
+
+        redisTemplate.opsForHash().put(key, roomId.toString(), "5");
+
+        mockMvc.perform(delete("/api/notifications/unread/{roomId}", roomId)
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isNoContent());
+
+        // Verify the room's count is removed
+        mockMvc.perform(get("/api/notifications/unread")
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$." + roomId).doesNotExist());
+    }
+
+    @Test
+    void clearUnread_nonExistentRoom_returns204() throws Exception {
+        UUID nonExistentRoomId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/notifications/unread/{roomId}", nonExistentRoomId)
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/api/src/test/java/com/example/chat/integration/PushSubscriptionIntegrationTest.java
+++ b/api/src/test/java/com/example/chat/integration/PushSubscriptionIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.example.chat.integration;
+
+import com.example.chat.model.entity.User;
+import com.example.chat.repository.PushSubscriptionRepository;
+import com.example.chat.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class PushSubscriptionIntegrationTest extends BaseIntegrationTest {
+
+    private static final String USER_ID = "test-user-push";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PushSubscriptionRepository pushSubscriptionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        pushSubscriptionRepository.deleteAll();
+
+        if (userRepository.findById(USER_ID).isEmpty()) {
+            User user = new User();
+            user.setId(USER_ID);
+            user.setEmail("push-test@example.com");
+            user.setDisplayName("Push Test User");
+            userRepository.save(user);
+        }
+    }
+
+    @Test
+    void getVapidKey_returnsPublicKey() throws Exception {
+        mockMvc.perform(get("/api/push/vapid-key")
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.publicKey").value(""));
+    }
+
+    @Test
+    void subscribe_storesSubscriptionInDb() throws Exception {
+        var request = Map.of(
+                "endpoint", "https://push.example.com/send/abc123",
+                "p256dh", "test-p256dh-key",
+                "auth", "test-auth-key"
+        );
+
+        mockMvc.perform(post("/api/push/subscribe")
+                        .with(jwt().jwt(j -> j.subject(USER_ID)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        var subscriptions = pushSubscriptionRepository.findByUserId(USER_ID);
+        assertThat(subscriptions).hasSize(1);
+        assertThat(subscriptions.get(0).getEndpoint()).isEqualTo("https://push.example.com/send/abc123");
+        assertThat(subscriptions.get(0).getP256dh()).isEqualTo("test-p256dh-key");
+        assertThat(subscriptions.get(0).getAuth()).isEqualTo("test-auth-key");
+    }
+
+    @Test
+    void subscribe_sameEndpointTwice_noDuplicate() throws Exception {
+        var request = Map.of(
+                "endpoint", "https://push.example.com/send/dup",
+                "p256dh", "test-p256dh-key",
+                "auth", "test-auth-key"
+        );
+        String body = objectMapper.writeValueAsString(request);
+
+        // Subscribe first time
+        mockMvc.perform(post("/api/push/subscribe")
+                        .with(jwt().jwt(j -> j.subject(USER_ID)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        // Subscribe second time with same endpoint
+        mockMvc.perform(post("/api/push/subscribe")
+                        .with(jwt().jwt(j -> j.subject(USER_ID)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk());
+
+        var subscriptions = pushSubscriptionRepository.findByUserId(USER_ID);
+        assertThat(subscriptions).hasSize(1);
+    }
+
+    @Test
+    void unsubscribe_deletesSubscriptionFromDb() throws Exception {
+        // First subscribe
+        var subscribeRequest = Map.of(
+                "endpoint", "https://push.example.com/send/to-delete",
+                "p256dh", "test-p256dh-key",
+                "auth", "test-auth-key"
+        );
+
+        mockMvc.perform(post("/api/push/subscribe")
+                        .with(jwt().jwt(j -> j.subject(USER_ID)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(subscribeRequest)))
+                .andExpect(status().isOk());
+
+        assertThat(pushSubscriptionRepository.findByUserId(USER_ID)).hasSize(1);
+
+        // Then unsubscribe
+        var unsubscribeRequest = Map.of("endpoint", "https://push.example.com/send/to-delete");
+
+        mockMvc.perform(delete("/api/push/unsubscribe")
+                        .with(jwt().jwt(j -> j.subject(USER_ID)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(unsubscribeRequest)))
+                .andExpect(status().isNoContent());
+
+        assertThat(pushSubscriptionRepository.findByUserId(USER_ID)).isEmpty();
+    }
+
+    @Test
+    void unsubscribe_nonExistentEndpoint_returns204() throws Exception {
+        var request = Map.of("endpoint", "https://push.example.com/send/nonexistent");
+
+        mockMvc.perform(delete("/api/push/unsubscribe")
+                        .with(jwt().jwt(j -> j.subject(USER_ID)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/api/src/test/java/com/example/chat/integration/RoomIntegrationTest.java
+++ b/api/src/test/java/com/example/chat/integration/RoomIntegrationTest.java
@@ -1,0 +1,210 @@
+package com.example.chat.integration;
+
+import com.example.chat.model.entity.ChatMessage;
+import com.example.chat.model.entity.ChatRoom;
+import com.example.chat.model.entity.RoomMember;
+import com.example.chat.model.entity.User;
+import com.example.chat.repository.ChatMessageRepository;
+import com.example.chat.repository.ChatRoomRepository;
+import com.example.chat.repository.FriendshipRepository;
+import com.example.chat.repository.PushSubscriptionRepository;
+import com.example.chat.repository.RoomMemberRepository;
+import com.example.chat.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class RoomIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private RoomMemberRepository roomMemberRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private FriendshipRepository friendshipRepository;
+
+    @Autowired
+    private PushSubscriptionRepository pushSubscriptionRepository;
+
+    private static final String USER_ID = "test-user-id";
+    private static final String OTHER_USER_ID = "other-user-id";
+
+    @BeforeEach
+    void setUp() {
+        chatMessageRepository.deleteAll();
+        roomMemberRepository.deleteAll();
+        chatRoomRepository.deleteAll();
+        friendshipRepository.deleteAll();
+        pushSubscriptionRepository.deleteAll();
+        userRepository.deleteAll();
+
+        var testUser = new User();
+        testUser.setId(USER_ID);
+        testUser.setEmail("test@example.com");
+        testUser.setDisplayName("Test User");
+        userRepository.save(testUser);
+
+        var otherUser = new User();
+        otherUser.setId(OTHER_USER_ID);
+        otherUser.setEmail("other@example.com");
+        otherUser.setDisplayName("Other User");
+        userRepository.save(otherUser);
+    }
+
+    @Test
+    void createRoom_returnsCreatedRoomWithMemberCount1() throws Exception {
+        mockMvc.perform(post("/api/rooms")
+                        .with(jwt().jwt(j -> j.subject(USER_ID)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"name": "test-room", "description": "A test room"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("test-room"))
+                .andExpect(jsonPath("$.description").value("A test room"))
+                .andExpect(jsonPath("$.createdBy").value(USER_ID))
+                .andExpect(jsonPath("$.memberCount").value(1))
+                .andExpect(jsonPath("$.id").isNotEmpty());
+    }
+
+    @Test
+    void listRooms_returnsOnlyRoomsUserBelongsTo() throws Exception {
+        // Create a room the user is a member of
+        var userRoom = createRoomInDb("user-room", "desc1", USER_ID);
+        addMemberToRoom(userRoom.getId(), USER_ID, "Test User", "OWNER");
+
+        // Create a room the user is NOT a member of
+        var otherRoom = createRoomInDb("other-room", "desc2", OTHER_USER_ID);
+        addMemberToRoom(otherRoom.getId(), OTHER_USER_ID, "Other User", "OWNER");
+
+        mockMvc.perform(get("/api/rooms")
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].name").value("user-room"));
+    }
+
+    @Test
+    void getRoom_returnsRoomDetailsWithMemberCount() throws Exception {
+        var room = createRoomInDb("detail-room", "detail desc", USER_ID);
+        addMemberToRoom(room.getId(), USER_ID, "Test User", "OWNER");
+        addMemberToRoom(room.getId(), OTHER_USER_ID, "Other User", "MEMBER");
+
+        mockMvc.perform(get("/api/rooms/{roomId}", room.getId())
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("detail-room"))
+                .andExpect(jsonPath("$.description").value("detail desc"))
+                .andExpect(jsonPath("$.memberCount").value(2));
+    }
+
+    @Test
+    void joinRoom_increasesMemberCount() throws Exception {
+        var room = createRoomInDb("join-room", "join desc", OTHER_USER_ID);
+        addMemberToRoom(room.getId(), OTHER_USER_ID, "Other User", "OWNER");
+
+        // Join the room
+        mockMvc.perform(post("/api/rooms/{roomId}/join", room.getId())
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isNoContent());
+
+        // Verify member count increased
+        mockMvc.perform(get("/api/rooms/{roomId}", room.getId())
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberCount").value(2));
+    }
+
+    @Test
+    void leaveRoom_removesMembership() throws Exception {
+        var room = createRoomInDb("leave-room", "leave desc", USER_ID);
+        addMemberToRoom(room.getId(), USER_ID, "Test User", "OWNER");
+        addMemberToRoom(room.getId(), OTHER_USER_ID, "Other User", "MEMBER");
+
+        // Leave the room
+        mockMvc.perform(delete("/api/rooms/{roomId}/leave", room.getId())
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isNoContent());
+
+        // Verify user's rooms no longer include this room
+        mockMvc.perform(get("/api/rooms")
+                        .with(jwt().jwt(j -> j.subject(USER_ID))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void getMessages_returnsPaginatedMessages() throws Exception {
+        var room = createRoomInDb("msg-room", "msg desc", USER_ID);
+        addMemberToRoom(room.getId(), USER_ID, "Test User", "OWNER");
+
+        // Insert messages directly
+        for (int i = 0; i < 3; i++) {
+            var msg = new ChatMessage();
+            msg.setRoomId(room.getId());
+            msg.setSenderId(USER_ID);
+            msg.setSenderName("Test User");
+            msg.setContent("Message " + i);
+            msg.setMessageType("TEXT");
+            chatMessageRepository.save(msg);
+        }
+
+        mockMvc.perform(get("/api/rooms/{roomId}/messages", room.getId())
+                        .with(jwt().jwt(j -> j.subject(USER_ID)))
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.totalPages").value(2))
+                .andExpect(jsonPath("$.content[0].senderId").value(USER_ID))
+                .andExpect(jsonPath("$.content[0].messageType").value("TEXT"));
+    }
+
+    @Test
+    void unauthenticatedRequest_returns401() throws Exception {
+        mockMvc.perform(get("/api/rooms"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private ChatRoom createRoomInDb(String name, String description, String createdBy) {
+        var room = new ChatRoom();
+        room.setName(name);
+        room.setDescription(description);
+        room.setCreatedBy(createdBy);
+        return chatRoomRepository.save(room);
+    }
+
+    private void addMemberToRoom(UUID roomId, String userId, String userName, String role) {
+        var member = new RoomMember();
+        member.setRoomId(roomId);
+        member.setUserId(userId);
+        member.setUserName(userName);
+        member.setRole(role);
+        roomMemberRepository.save(member);
+    }
+}

--- a/api/src/test/java/com/example/chat/integration/UserIntegrationTest.java
+++ b/api/src/test/java/com/example/chat/integration/UserIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.example.chat.integration;
+
+import com.example.chat.model.entity.User;
+import com.example.chat.repository.FriendshipRepository;
+import com.example.chat.repository.PushSubscriptionRepository;
+import com.example.chat.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class UserIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FriendshipRepository friendshipRepository;
+
+    @Autowired
+    private PushSubscriptionRepository pushSubscriptionRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        friendshipRepository.deleteAll();
+        pushSubscriptionRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser = new User();
+        testUser.setId("test-user-id");
+        testUser.setEmail("testuser@example.com");
+        testUser.setDisplayName("TestUser");
+        userRepository.save(testUser);
+    }
+
+    @Test
+    void getMe_returnsCurrentUserProfile() throws Exception {
+        mockMvc.perform(get("/api/users/me")
+                        .with(jwt().jwt(j -> j.subject(testUser.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(testUser.getId()))
+                .andExpect(jsonPath("$.email").value("testuser@example.com"))
+                .andExpect(jsonPath("$.displayName").value("TestUser"));
+    }
+
+    @Test
+    void searchUsers_returnsMatchingResults() throws Exception {
+        var anotherUser = new User();
+        anotherUser.setId("another-user-id");
+        anotherUser.setEmail("another@example.com");
+        anotherUser.setDisplayName("AnotherUser");
+        userRepository.save(anotherUser);
+
+        mockMvc.perform(get("/api/users/search")
+                        .param("q", "another")
+                        .with(jwt().jwt(j -> j.subject(testUser.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value("another-user-id"))
+                .andExpect(jsonPath("$[0].displayName").value("AnotherUser"));
+    }
+
+    @Test
+    void searchUsers_noResults_returnsEmptyList() throws Exception {
+        mockMvc.perform(get("/api/users/search")
+                        .param("q", "nonexistent")
+                        .with(jwt().jwt(j -> j.subject(testUser.getId()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+}

--- a/api/src/test/java/com/example/chat/service/ChatServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/ChatServiceTest.java
@@ -1,0 +1,176 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.MessageResponse;
+import com.example.chat.model.entity.ChatMessage;
+import com.example.chat.repository.ChatMessageRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceTest {
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private SearchService searchService;
+
+    @Mock
+    private SqsNotificationService sqsNotificationService;
+
+    @InjectMocks
+    private ChatService chatService;
+
+    // --- saveMessage tests ---
+
+    @Test
+    void saveMessage_savesWithCorrectFieldsAndReturnsSavedEntity() {
+        UUID roomId = UUID.randomUUID();
+        String senderId = "user-1";
+        String senderName = "Alice";
+        String content = "Hello!";
+        String messageType = "TEXT";
+
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenAnswer(invocation -> {
+            ChatMessage msg = invocation.getArgument(0);
+            msg.setId(UUID.randomUUID());
+            msg.setCreatedAt(Instant.now());
+            return msg;
+        });
+
+        ChatMessage result = chatService.saveMessage(roomId, senderId, senderName, content, messageType);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isNotNull();
+        assertThat(result.getRoomId()).isEqualTo(roomId);
+        assertThat(result.getSenderId()).isEqualTo(senderId);
+        assertThat(result.getSenderName()).isEqualTo(senderName);
+        assertThat(result.getContent()).isEqualTo(content);
+        assertThat(result.getMessageType()).isEqualTo(messageType);
+
+        ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
+        verify(chatMessageRepository).save(captor.capture());
+        ChatMessage saved = captor.getValue();
+        assertThat(saved.getRoomId()).isEqualTo(roomId);
+        assertThat(saved.getSenderId()).isEqualTo(senderId);
+        assertThat(saved.getSenderName()).isEqualTo(senderName);
+        assertThat(saved.getContent()).isEqualTo(content);
+        assertThat(saved.getMessageType()).isEqualTo(messageType);
+    }
+
+    @Test
+    void saveMessage_callsSearchServiceIndexMessage() {
+        UUID roomId = UUID.randomUUID();
+        ChatMessage savedMsg = buildSavedMessage(roomId);
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMsg);
+
+        chatService.saveMessage(roomId, "user-1", "Alice", "Hello!", "TEXT");
+
+        verify(searchService).indexMessage(savedMsg);
+    }
+
+    @Test
+    void saveMessage_callsSqsNotificationServiceSendNotification() {
+        UUID roomId = UUID.randomUUID();
+        ChatMessage savedMsg = buildSavedMessage(roomId);
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMsg);
+
+        chatService.saveMessage(roomId, "user-1", "Alice", "Hello!", "TEXT");
+
+        verify(sqsNotificationService).sendNotification(savedMsg);
+    }
+
+    @Test
+    void saveMessage_whenSearchServiceThrows_messageIsStillSavedAndReturned() {
+        UUID roomId = UUID.randomUUID();
+        ChatMessage savedMsg = buildSavedMessage(roomId);
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMsg);
+        doThrow(new RuntimeException("ES is down")).when(searchService).indexMessage(any());
+
+        ChatMessage result = chatService.saveMessage(roomId, "user-1", "Alice", "Hello!", "TEXT");
+
+        assertThat(result).isSameAs(savedMsg);
+        verify(chatMessageRepository).save(any(ChatMessage.class));
+    }
+
+    @Test
+    void saveMessage_whenSqsNotificationServiceThrows_messageIsStillSavedAndReturned() {
+        UUID roomId = UUID.randomUUID();
+        ChatMessage savedMsg = buildSavedMessage(roomId);
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMsg);
+        doThrow(new RuntimeException("SQS is down")).when(sqsNotificationService).sendNotification(any());
+
+        ChatMessage result = chatService.saveMessage(roomId, "user-1", "Alice", "Hello!", "TEXT");
+
+        assertThat(result).isSameAs(savedMsg);
+        verify(chatMessageRepository).save(any(ChatMessage.class));
+    }
+
+    // --- getMessages tests ---
+
+    @Test
+    void getMessages_returnsMappedMessageResponsePage() {
+        UUID roomId = UUID.randomUUID();
+        ChatMessage msg = buildSavedMessage(roomId);
+        Page<ChatMessage> page = new PageImpl<>(List.of(msg));
+        when(chatMessageRepository.findByRoomIdOrderByCreatedAtDesc(eq(roomId), any(PageRequest.class)))
+                .thenReturn(page);
+
+        Page<MessageResponse> result = chatService.getMessages(roomId, 0, 20);
+
+        assertThat(result.getContent()).hasSize(1);
+        MessageResponse response = result.getContent().get(0);
+        assertThat(response.id()).isEqualTo(msg.getId());
+        assertThat(response.senderId()).isEqualTo(msg.getSenderId());
+        assertThat(response.senderName()).isEqualTo(msg.getSenderName());
+        assertThat(response.content()).isEqualTo(msg.getContent());
+        assertThat(response.messageType()).isEqualTo(msg.getMessageType());
+        assertThat(response.createdAt()).isEqualTo(msg.getCreatedAt());
+    }
+
+    @Test
+    void getMessages_passesCorrectPageRequestToRepository() {
+        UUID roomId = UUID.randomUUID();
+        int pageNum = 2;
+        int size = 10;
+        when(chatMessageRepository.findByRoomIdOrderByCreatedAtDesc(any(), any()))
+                .thenReturn(Page.empty());
+
+        chatService.getMessages(roomId, pageNum, size);
+
+        ArgumentCaptor<PageRequest> captor = ArgumentCaptor.forClass(PageRequest.class);
+        verify(chatMessageRepository).findByRoomIdOrderByCreatedAtDesc(eq(roomId), captor.capture());
+        PageRequest captured = captor.getValue();
+        assertThat(captured.getPageNumber()).isEqualTo(pageNum);
+        assertThat(captured.getPageSize()).isEqualTo(size);
+    }
+
+    // --- helpers ---
+
+    private ChatMessage buildSavedMessage(UUID roomId) {
+        ChatMessage msg = new ChatMessage();
+        msg.setId(UUID.randomUUID());
+        msg.setRoomId(roomId);
+        msg.setSenderId("user-1");
+        msg.setSenderName("Alice");
+        msg.setContent("Hello!");
+        msg.setMessageType("TEXT");
+        msg.setCreatedAt(Instant.now());
+        return msg;
+    }
+}

--- a/api/src/test/java/com/example/chat/service/FileServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/FileServiceTest.java
@@ -1,0 +1,109 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.PresignedUrlResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileServiceTest {
+
+    @Mock
+    private S3Presigner s3Presigner;
+
+    private final String bucketName = "test-bucket";
+
+    private FileService fileService;
+
+    private FileService createFileService() {
+        return new FileService(s3Presigner, bucketName);
+    }
+
+    @Test
+    void generateUploadUrl_returnsPresignedUrlAndS3Key() throws MalformedURLException {
+        fileService = createFileService();
+        UUID roomId = UUID.randomUUID();
+        String fileName = "photo.png";
+        String contentType = "image/png";
+        URL expectedUrl = URI.create("https://s3.amazonaws.com/test-bucket/uploads/test-key").toURL();
+
+        PresignedPutObjectRequest presignedRequest = mock(PresignedPutObjectRequest.class);
+        when(presignedRequest.url()).thenReturn(expectedUrl);
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(presignedRequest);
+
+        PresignedUrlResponse result = fileService.generateUploadUrl(roomId, fileName, contentType);
+
+        assertThat(result.uploadUrl()).isEqualTo(expectedUrl.toString());
+        assertThat(result.s3Key()).startsWith("uploads/" + roomId + "/");
+        assertThat(result.s3Key()).endsWith("/" + fileName);
+
+        ArgumentCaptor<PutObjectPresignRequest> captor = ArgumentCaptor.forClass(PutObjectPresignRequest.class);
+        verify(s3Presigner).presignPutObject(captor.capture());
+
+        PutObjectPresignRequest captured = captor.getValue();
+        assertThat(captured.signatureDuration()).isEqualTo(Duration.ofMinutes(15));
+        assertThat(captured.putObjectRequest().bucket()).isEqualTo(bucketName);
+        assertThat(captured.putObjectRequest().contentType()).isEqualTo(contentType);
+        assertThat(captured.putObjectRequest().key()).startsWith("uploads/" + roomId + "/");
+    }
+
+    @Test
+    void generateUploadUrl_generatesUniqueS3KeysForSameFile() throws MalformedURLException {
+        fileService = createFileService();
+        UUID roomId = UUID.randomUUID();
+        URL dummyUrl = URI.create("https://s3.amazonaws.com/test-bucket/dummy").toURL();
+
+        PresignedPutObjectRequest presignedRequest = mock(PresignedPutObjectRequest.class);
+        when(presignedRequest.url()).thenReturn(dummyUrl);
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(presignedRequest);
+
+        PresignedUrlResponse result1 = fileService.generateUploadUrl(roomId, "file.txt", "text/plain");
+        PresignedUrlResponse result2 = fileService.generateUploadUrl(roomId, "file.txt", "text/plain");
+
+        assertThat(result1.s3Key()).isNotEqualTo(result2.s3Key());
+    }
+
+    @Test
+    void generateDownloadUrl_returnsPresignedGetUrl() throws MalformedURLException {
+        fileService = createFileService();
+        String s3Key = "uploads/some-room/some-uuid/photo.png";
+        URL expectedUrl = URI.create("https://s3.amazonaws.com/test-bucket/" + s3Key).toURL();
+
+        PresignedGetObjectRequest presignedRequest = mock(PresignedGetObjectRequest.class);
+        when(presignedRequest.url()).thenReturn(expectedUrl);
+        when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).thenReturn(presignedRequest);
+
+        String result = fileService.generateDownloadUrl(s3Key);
+
+        assertThat(result).isEqualTo(expectedUrl.toString());
+
+        ArgumentCaptor<GetObjectPresignRequest> captor = ArgumentCaptor.forClass(GetObjectPresignRequest.class);
+        verify(s3Presigner).presignGetObject(captor.capture());
+
+        GetObjectPresignRequest captured = captor.getValue();
+        assertThat(captured.signatureDuration()).isEqualTo(Duration.ofHours(1));
+        assertThat(captured.getObjectRequest().bucket()).isEqualTo(bucketName);
+        assertThat(captured.getObjectRequest().key()).isEqualTo(s3Key);
+    }
+}

--- a/api/src/test/java/com/example/chat/service/FriendServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/FriendServiceTest.java
@@ -1,0 +1,201 @@
+package com.example.chat.service;
+
+import com.example.chat.model.entity.Friendship;
+import com.example.chat.model.entity.User;
+import com.example.chat.repository.FriendshipRepository;
+import com.example.chat.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FriendServiceTest {
+
+    @Mock
+    private FriendshipRepository friendshipRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private FriendService friendService;
+
+    @Test
+    void sendRequest_createsPendingFriendship() {
+        when(friendshipRepository.findBetween("user1", "user2")).thenReturn(Optional.empty());
+        when(friendshipRepository.save(any(Friendship.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Friendship result = friendService.sendRequest("user1", "user2");
+
+        assertThat(result.getUserId()).isEqualTo("user1");
+        assertThat(result.getFriendId()).isEqualTo("user2");
+        assertThat(result.getStatus()).isEqualTo("PENDING");
+
+        ArgumentCaptor<Friendship> captor = ArgumentCaptor.forClass(Friendship.class);
+        verify(friendshipRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo("PENDING");
+    }
+
+    @Test
+    void sendRequest_throwsOnSelfRequest() {
+        assertThatThrownBy(() -> friendService.sendRequest("user1", "user1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot send friend request to yourself");
+    }
+
+    @Test
+    void sendRequest_throwsIfAlreadyExists() {
+        var existing = new Friendship();
+        existing.setUserId("user1");
+        existing.setFriendId("user2");
+        existing.setStatus("PENDING");
+
+        when(friendshipRepository.findBetween("user1", "user2")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> friendService.sendRequest("user1", "user2"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Friendship already exists");
+    }
+
+    @Test
+    void acceptRequest_setsStatusToAccepted() {
+        var friendship = new Friendship();
+        friendship.setUserId("requester");
+        friendship.setFriendId("recipient");
+        friendship.setStatus("PENDING");
+
+        when(friendshipRepository.findBetween("requester", "recipient")).thenReturn(Optional.of(friendship));
+        when(friendshipRepository.save(any(Friendship.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Friendship result = friendService.acceptRequest("recipient", "requester");
+
+        assertThat(result.getStatus()).isEqualTo("ACCEPTED");
+        verify(friendshipRepository).save(friendship);
+    }
+
+    @Test
+    void acceptRequest_throwsIfNotRecipient() {
+        var friendship = new Friendship();
+        friendship.setUserId("requester");
+        friendship.setFriendId("someone-else");
+        friendship.setStatus("PENDING");
+
+        when(friendshipRepository.findBetween("requester", "not-recipient")).thenReturn(Optional.of(friendship));
+
+        assertThatThrownBy(() -> friendService.acceptRequest("not-recipient", "requester"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Only the recipient can accept");
+    }
+
+    @Test
+    void acceptRequest_throwsIfNotFound() {
+        when(friendshipRepository.findBetween("requester", "recipient")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> friendService.acceptRequest("recipient", "requester"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Friend request not found");
+    }
+
+    @Test
+    void removeFriend_deletesFriendship() {
+        var friendship = new Friendship();
+        friendship.setUserId("user1");
+        friendship.setFriendId("user2");
+
+        when(friendshipRepository.findBetween("user1", "user2")).thenReturn(Optional.of(friendship));
+
+        friendService.removeFriend("user1", "user2");
+
+        verify(friendshipRepository).delete(friendship);
+    }
+
+    @Test
+    void removeFriend_doesNothingIfNotFound() {
+        when(friendshipRepository.findBetween("user1", "user2")).thenReturn(Optional.empty());
+
+        friendService.removeFriend("user1", "user2");
+
+        verify(friendshipRepository, never()).delete(any());
+    }
+
+    @Test
+    void getFriends_returnsAcceptedFriendsAsUsers() {
+        var friendship1 = new Friendship();
+        friendship1.setUserId("user1");
+        friendship1.setFriendId("user2");
+        friendship1.setStatus("ACCEPTED");
+
+        var friendship2 = new Friendship();
+        friendship2.setUserId("user3");
+        friendship2.setFriendId("user1");
+        friendship2.setStatus("ACCEPTED");
+
+        when(friendshipRepository.findAcceptedFriends("user1")).thenReturn(List.of(friendship1, friendship2));
+
+        var user2 = new User();
+        user2.setId("user2");
+        user2.setEmail("user2@example.com");
+        user2.setDisplayName("User2");
+
+        var user3 = new User();
+        user3.setId("user3");
+        user3.setEmail("user3@example.com");
+        user3.setDisplayName("User3");
+
+        when(userRepository.findById("user2")).thenReturn(Optional.of(user2));
+        when(userRepository.findById("user3")).thenReturn(Optional.of(user3));
+
+        List<User> friends = friendService.getFriends("user1");
+
+        assertThat(friends).hasSize(2);
+        assertThat(friends).extracting(User::getId).containsExactly("user2", "user3");
+    }
+
+    @Test
+    void getFriends_filtersOutNullUsers() {
+        var friendship = new Friendship();
+        friendship.setUserId("user1");
+        friendship.setFriendId("deleted-user");
+        friendship.setStatus("ACCEPTED");
+
+        when(friendshipRepository.findAcceptedFriends("user1")).thenReturn(List.of(friendship));
+        when(userRepository.findById("deleted-user")).thenReturn(Optional.empty());
+
+        List<User> friends = friendService.getFriends("user1");
+
+        assertThat(friends).isEmpty();
+    }
+
+    @Test
+    void getPendingRequests_returnsPendingForUser() {
+        var pending1 = new Friendship();
+        pending1.setUserId("sender1");
+        pending1.setFriendId("user1");
+        pending1.setStatus("PENDING");
+
+        var pending2 = new Friendship();
+        pending2.setUserId("sender2");
+        pending2.setFriendId("user1");
+        pending2.setStatus("PENDING");
+
+        when(friendshipRepository.findByFriendIdAndStatus("user1", "PENDING"))
+                .thenReturn(List.of(pending1, pending2));
+
+        List<Friendship> requests = friendService.getPendingRequests("user1");
+
+        assertThat(requests).hasSize(2);
+        assertThat(requests).allMatch(f -> f.getFriendId().equals("user1"));
+        assertThat(requests).allMatch(f -> f.getStatus().equals("PENDING"));
+    }
+}

--- a/api/src/test/java/com/example/chat/service/NotificationServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/NotificationServiceTest.java
@@ -1,0 +1,186 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.model.dto.NotificationPayload;
+import com.example.chat.model.entity.RoomMember;
+import com.example.chat.repository.RoomMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private RoomMemberRepository roomMemberRepository;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    @Captor
+    private ArgumentCaptor<NotificationPayload> payloadCaptor;
+
+    private NotificationService notificationService;
+
+    private static final UUID ROOM_ID = UUID.randomUUID();
+    private static final UUID MESSAGE_ID = UUID.randomUUID();
+    private static final String SENDER_ID = "sender-001";
+    private static final String SENDER_NAME = "Alice";
+    private static final Instant CREATED_AT = Instant.parse("2026-01-15T10:30:00Z");
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationService(
+                messagingTemplate, roomMemberRepository, redisTemplate);
+    }
+
+    @Test
+    void sendsStompNotificationToAllMembersExceptSender() {
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        var members = List.of(
+                createMember(SENDER_ID, "Alice"),
+                createMember("user-002", "Bob"),
+                createMember("user-003", "Charlie"));
+        when(roomMemberRepository.findByRoomId(ROOM_ID)).thenReturn(members);
+
+        var event = createEvent("Hello everyone");
+        notificationService.notifyRoomMembers(event);
+
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("user-002"), eq("/queue/notifications"), any());
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("user-003"), eq("/queue/notifications"), any());
+        verify(messagingTemplate, times(2))
+                .convertAndSendToUser(anyString(), anyString(), any());
+    }
+
+    @Test
+    void doesNotSendNotificationToSender() {
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        var members = List.of(
+                createMember(SENDER_ID, "Alice"),
+                createMember("user-002", "Bob"));
+        when(roomMemberRepository.findByRoomId(ROOM_ID)).thenReturn(members);
+
+        var event = createEvent("Hello");
+        notificationService.notifyRoomMembers(event);
+
+        verify(messagingTemplate, never()).convertAndSendToUser(
+                eq(SENDER_ID), anyString(), any());
+    }
+
+    @Test
+    void incrementsRedisUnreadCountForEachRecipient() {
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        var members = List.of(
+                createMember(SENDER_ID, "Alice"),
+                createMember("user-002", "Bob"),
+                createMember("user-003", "Charlie"));
+        when(roomMemberRepository.findByRoomId(ROOM_ID)).thenReturn(members);
+
+        var event = createEvent("Hello");
+        notificationService.notifyRoomMembers(event);
+
+        verify(hashOperations).increment(
+                "unread:user-002", ROOM_ID.toString(), 1);
+        verify(hashOperations).increment(
+                "unread:user-003", ROOM_ID.toString(), 1);
+        verify(hashOperations, never()).increment(
+                eq("unread:" + SENDER_ID), anyString(), anyLong());
+    }
+
+    @Test
+    void truncatesContentLongerThan100Chars() {
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        var members = List.of(
+                createMember(SENDER_ID, "Alice"),
+                createMember("user-002", "Bob"));
+        when(roomMemberRepository.findByRoomId(ROOM_ID)).thenReturn(members);
+
+        var longContent = "a".repeat(150);
+        var event = createEvent(longContent);
+        notificationService.notifyRoomMembers(event);
+
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("user-002"), eq("/queue/notifications"), payloadCaptor.capture());
+
+        var payload = payloadCaptor.getValue();
+        assertThat(payload.contentPreview()).hasSize(103); // 100 chars + "..."
+    }
+
+    @Test
+    void handlesNullContentGracefully() {
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        var members = List.of(
+                createMember(SENDER_ID, "Alice"),
+                createMember("user-002", "Bob"));
+        when(roomMemberRepository.findByRoomId(ROOM_ID)).thenReturn(members);
+
+        var event = new ChatNotificationEvent(
+                MESSAGE_ID, ROOM_ID, SENDER_ID, SENDER_NAME,
+                null, "TEXT", CREATED_AT);
+        notificationService.notifyRoomMembers(event);
+
+        verify(messagingTemplate).convertAndSendToUser(
+                eq("user-002"), eq("/queue/notifications"), payloadCaptor.capture());
+
+        var payload = payloadCaptor.getValue();
+        assertThat(payload.contentPreview()).isEmpty();
+    }
+
+    @Test
+    void worksWithEmptyMemberList() {
+        when(roomMemberRepository.findByRoomId(ROOM_ID))
+                .thenReturn(Collections.emptyList());
+
+        var event = createEvent("Hello");
+
+        assertThatNoException().isThrownBy(
+                () -> notificationService.notifyRoomMembers(event));
+
+        verifyNoInteractions(messagingTemplate);
+        verify(redisTemplate, never()).opsForHash();
+    }
+
+    private ChatNotificationEvent createEvent(String content) {
+        return new ChatNotificationEvent(
+                MESSAGE_ID, ROOM_ID, SENDER_ID, SENDER_NAME,
+                content, "TEXT", CREATED_AT);
+    }
+
+    private RoomMember createMember(String userId, String userName) {
+        var member = new RoomMember();
+        member.setRoomId(ROOM_ID);
+        member.setUserId(userId);
+        member.setUserName(userName);
+        member.setRole("MEMBER");
+        member.setJoinedAt(Instant.now());
+        return member;
+    }
+}

--- a/api/src/test/java/com/example/chat/service/PresenceServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/PresenceServiceTest.java
@@ -1,0 +1,106 @@
+package com.example.chat.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PresenceServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private PresenceService presenceService;
+
+    @Test
+    void setOnline_setsRedisKeyWithTtl() {
+        String userId = "user-1";
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        presenceService.setOnline(userId);
+
+        verify(valueOperations).set("user:user-1:online", "true", Duration.ofSeconds(300));
+    }
+
+    @Test
+    void setOffline_deletesRedisKey() {
+        String userId = "user-1";
+
+        presenceService.setOffline(userId);
+
+        verify(redisTemplate).delete("user:user-1:online");
+    }
+
+    @Test
+    void isOnline_returnsTrueWhenKeyExists() {
+        String userId = "user-1";
+        when(redisTemplate.hasKey("user:user-1:online")).thenReturn(true);
+
+        boolean result = presenceService.isOnline(userId);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isOnline_returnsFalseWhenKeyDoesNotExist() {
+        String userId = "user-1";
+        when(redisTemplate.hasKey("user:user-1:online")).thenReturn(false);
+
+        boolean result = presenceService.isOnline(userId);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isOnline_returnsFalseWhenHasKeyReturnsNull() {
+        String userId = "user-1";
+        when(redisTemplate.hasKey("user:user-1:online")).thenReturn(null);
+
+        boolean result = presenceService.isOnline(userId);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void getOnlineUsers_filtersToOnlyOnlineUsers() {
+        when(redisTemplate.hasKey("user:user-1:online")).thenReturn(true);
+        when(redisTemplate.hasKey("user:user-2:online")).thenReturn(false);
+        when(redisTemplate.hasKey("user:user-3:online")).thenReturn(true);
+
+        List<String> result = presenceService.getOnlineUsers(List.of("user-1", "user-2", "user-3"));
+
+        assertThat(result).containsExactly("user-1", "user-3");
+    }
+
+    @Test
+    void getOnlineUsers_returnsEmptyListWhenNoOneIsOnline() {
+        when(redisTemplate.hasKey("user:user-1:online")).thenReturn(false);
+        when(redisTemplate.hasKey("user:user-2:online")).thenReturn(false);
+
+        List<String> result = presenceService.getOnlineUsers(List.of("user-1", "user-2"));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getOnlineUsers_returnsEmptyListForEmptyInput() {
+        List<String> result = presenceService.getOnlineUsers(List.of());
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/api/src/test/java/com/example/chat/service/RoomServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/RoomServiceTest.java
@@ -1,0 +1,205 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.RoomResponse;
+import com.example.chat.model.entity.ChatMessage;
+import com.example.chat.model.entity.ChatRoom;
+import com.example.chat.model.entity.RoomMember;
+import com.example.chat.repository.ChatRoomRepository;
+import com.example.chat.repository.RoomMemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RoomServiceTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private RoomMemberRepository roomMemberRepository;
+
+    @Mock
+    private ChatService chatService;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private RoomService roomService;
+
+    @Test
+    void createRoom_savesRoomAndOwnerMember_returnsRoomResponse() {
+        var roomId = UUID.randomUUID();
+        var now = Instant.now();
+
+        when(chatRoomRepository.save(any(ChatRoom.class))).thenAnswer(invocation -> {
+            ChatRoom room = invocation.getArgument(0);
+            room.setId(roomId);
+            room.setCreatedAt(now);
+            return room;
+        });
+        when(roomMemberRepository.save(any(RoomMember.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RoomResponse response = roomService.createRoom("general", "General chat", "user1", "Alice");
+
+        assertThat(response.id()).isEqualTo(roomId);
+        assertThat(response.name()).isEqualTo("general");
+        assertThat(response.description()).isEqualTo("General chat");
+        assertThat(response.createdBy()).isEqualTo("user1");
+        assertThat(response.memberCount()).isEqualTo(1);
+
+        ArgumentCaptor<RoomMember> memberCaptor = ArgumentCaptor.forClass(RoomMember.class);
+        verify(roomMemberRepository).save(memberCaptor.capture());
+        RoomMember savedMember = memberCaptor.getValue();
+        assertThat(savedMember.getRoomId()).isEqualTo(roomId);
+        assertThat(savedMember.getUserId()).isEqualTo("user1");
+        assertThat(savedMember.getUserName()).isEqualTo("Alice");
+        assertThat(savedMember.getRole()).isEqualTo("OWNER");
+    }
+
+    @Test
+    void listRooms_returnsMemberRoomsWithCounts() {
+        var roomId1 = UUID.randomUUID();
+        var roomId2 = UUID.randomUUID();
+        var now = Instant.now();
+
+        var membership1 = new RoomMember();
+        membership1.setRoomId(roomId1);
+        membership1.setUserId("user1");
+        var membership2 = new RoomMember();
+        membership2.setRoomId(roomId2);
+        membership2.setUserId("user1");
+
+        when(roomMemberRepository.findByUserId("user1")).thenReturn(List.of(membership1, membership2));
+
+        var room1 = new ChatRoom();
+        room1.setId(roomId1);
+        room1.setName("room1");
+        room1.setCreatedBy("user1");
+        room1.setCreatedAt(now);
+        var room2 = new ChatRoom();
+        room2.setId(roomId2);
+        room2.setName("room2");
+        room2.setCreatedBy("user2");
+        room2.setCreatedAt(now);
+
+        when(chatRoomRepository.findById(roomId1)).thenReturn(Optional.of(room1));
+        when(chatRoomRepository.findById(roomId2)).thenReturn(Optional.of(room2));
+
+        var member1 = new RoomMember();
+        var member2 = new RoomMember();
+        var member3 = new RoomMember();
+        when(roomMemberRepository.findByRoomId(roomId1)).thenReturn(List.of(member1, member2));
+        when(roomMemberRepository.findByRoomId(roomId2)).thenReturn(List.of(member3));
+
+        List<RoomResponse> rooms = roomService.listRooms("user1");
+
+        assertThat(rooms).hasSize(2);
+        assertThat(rooms.get(0).name()).isEqualTo("room1");
+        assertThat(rooms.get(0).memberCount()).isEqualTo(2);
+        assertThat(rooms.get(1).name()).isEqualTo("room2");
+        assertThat(rooms.get(1).memberCount()).isEqualTo(1);
+    }
+
+    @Test
+    void getRoom_returnsRoomResponseWithMemberCount() {
+        var roomId = UUID.randomUUID();
+        var now = Instant.now();
+
+        var room = new ChatRoom();
+        room.setId(roomId);
+        room.setName("test-room");
+        room.setDescription("A test room");
+        room.setCreatedBy("user1");
+        room.setCreatedAt(now);
+
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(room));
+        when(roomMemberRepository.findByRoomId(roomId)).thenReturn(List.of(new RoomMember(), new RoomMember(), new RoomMember()));
+
+        RoomResponse response = roomService.getRoom(roomId);
+
+        assertThat(response.id()).isEqualTo(roomId);
+        assertThat(response.name()).isEqualTo("test-room");
+        assertThat(response.memberCount()).isEqualTo(3);
+    }
+
+    @Test
+    void getRoom_throwsEntityNotFoundExceptionWhenRoomNotFound() {
+        var roomId = UUID.randomUUID();
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> roomService.getRoom(roomId))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Room not found");
+    }
+
+    @Test
+    void joinRoom_savesMemberAndBroadcastsSystemMessage() {
+        var roomId = UUID.randomUUID();
+        var messageId = UUID.randomUUID();
+        var now = Instant.now();
+
+        when(roomMemberRepository.findByRoomIdAndUserId(roomId, "user2")).thenReturn(Optional.empty());
+        when(roomMemberRepository.save(any(RoomMember.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var systemMessage = new ChatMessage();
+        systemMessage.setId(messageId);
+        systemMessage.setSenderId("SYSTEM");
+        systemMessage.setSenderName("SYSTEM");
+        systemMessage.setContent("Bob joined");
+        systemMessage.setMessageType("SYSTEM");
+        systemMessage.setCreatedAt(now);
+
+        when(chatService.saveMessage(roomId, "SYSTEM", "SYSTEM", "Bob joined", "SYSTEM"))
+                .thenReturn(systemMessage);
+
+        roomService.joinRoom(roomId, "user2", "Bob");
+
+        ArgumentCaptor<RoomMember> memberCaptor = ArgumentCaptor.forClass(RoomMember.class);
+        verify(roomMemberRepository).save(memberCaptor.capture());
+        assertThat(memberCaptor.getValue().getUserId()).isEqualTo("user2");
+        assertThat(memberCaptor.getValue().getUserName()).isEqualTo("Bob");
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/room." + roomId), any(com.example.chat.model.dto.MessageResponse.class));
+    }
+
+    @Test
+    void joinRoom_doesNothingWhenAlreadyMember() {
+        var roomId = UUID.randomUUID();
+        var existingMember = new RoomMember();
+
+        when(roomMemberRepository.findByRoomIdAndUserId(roomId, "user1")).thenReturn(Optional.of(existingMember));
+
+        roomService.joinRoom(roomId, "user1", "Alice");
+
+        verify(roomMemberRepository, never()).save(any());
+        verify(chatService, never()).saveMessage(any(), any(), any(), any(), any());
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
+    }
+
+    @Test
+    void leaveRoom_deletesMembership() {
+        var roomId = UUID.randomUUID();
+
+        roomService.leaveRoom(roomId, "user1");
+
+        verify(roomMemberRepository).deleteByRoomIdAndUserId(roomId, "user1");
+    }
+}

--- a/api/src/test/java/com/example/chat/service/SearchServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/SearchServiceTest.java
@@ -1,0 +1,127 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.MessageResponse;
+import com.example.chat.model.entity.ChatMessage;
+import com.example.chat.model.entity.ChatMessageDocument;
+import com.example.chat.repository.ChatMessageSearchRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest {
+
+    @Mock
+    private ChatMessageSearchRepository chatMessageSearchRepository;
+
+    @InjectMocks
+    private SearchService searchService;
+
+    @Test
+    void indexMessage_convertsChatMessageToDocumentAndSaves() {
+        ChatMessage message = new ChatMessage();
+        UUID messageId = UUID.randomUUID();
+        UUID roomId = UUID.randomUUID();
+        Instant now = Instant.now();
+
+        message.setId(messageId);
+        message.setRoomId(roomId);
+        message.setSenderId("user-1");
+        message.setSenderName("Alice");
+        message.setContent("Hello, world!");
+        message.setMessageType("TEXT");
+        message.setCreatedAt(now);
+
+        searchService.indexMessage(message);
+
+        ArgumentCaptor<ChatMessageDocument> captor = ArgumentCaptor.forClass(ChatMessageDocument.class);
+        verify(chatMessageSearchRepository).save(captor.capture());
+
+        ChatMessageDocument saved = captor.getValue();
+        assertThat(saved.getId()).isEqualTo(messageId.toString());
+        assertThat(saved.getRoomId()).isEqualTo(roomId.toString());
+        assertThat(saved.getSenderId()).isEqualTo("user-1");
+        assertThat(saved.getSenderName()).isEqualTo("Alice");
+        assertThat(saved.getContent()).isEqualTo("Hello, world!");
+        assertThat(saved.getMessageType()).isEqualTo("TEXT");
+        assertThat(saved.getCreatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    void searchMessages_returnsPageOfMessageResponses() {
+        UUID roomId = UUID.randomUUID();
+        UUID docId = UUID.randomUUID();
+        Instant now = Instant.now();
+        String query = "hello";
+        int page = 0;
+        int size = 10;
+
+        ChatMessageDocument doc = new ChatMessageDocument();
+        // Use reflection or create via ChatMessage constructor
+        ChatMessage msg = new ChatMessage();
+        msg.setId(docId);
+        msg.setRoomId(roomId);
+        msg.setSenderId("user-2");
+        msg.setSenderName("Bob");
+        msg.setContent("hello there");
+        msg.setMessageType("TEXT");
+        msg.setCreatedAt(now);
+        ChatMessageDocument document = new ChatMessageDocument(msg);
+
+        Pageable expectedPageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<ChatMessageDocument> docPage = new PageImpl<>(List.of(document), expectedPageable, 1);
+
+        when(chatMessageSearchRepository.findByRoomIdAndContentContaining(
+                eq(roomId.toString()), eq(query), eq(expectedPageable)))
+                .thenReturn(docPage);
+
+        Page<MessageResponse> result = searchService.searchMessages(roomId, query, page, size);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        MessageResponse response = result.getContent().get(0);
+        assertThat(response.id()).isEqualTo(docId);
+        assertThat(response.senderId()).isEqualTo("user-2");
+        assertThat(response.senderName()).isEqualTo("Bob");
+        assertThat(response.content()).isEqualTo("hello there");
+        assertThat(response.messageType()).isEqualTo("TEXT");
+        assertThat(response.createdAt()).isEqualTo(now);
+    }
+
+    @Test
+    void searchMessages_returnsEmptyPageWhenNoResults() {
+        UUID roomId = UUID.randomUUID();
+        String query = "nonexistent";
+        int page = 0;
+        int size = 10;
+
+        Pageable expectedPageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<ChatMessageDocument> emptyPage = new PageImpl<>(List.of(), expectedPageable, 0);
+
+        when(chatMessageSearchRepository.findByRoomIdAndContentContaining(
+                eq(roomId.toString()), eq(query), eq(expectedPageable)))
+                .thenReturn(emptyPage);
+
+        Page<MessageResponse> result = searchService.searchMessages(roomId, query, page, size);
+
+        assertThat(result.getTotalElements()).isZero();
+        assertThat(result.getContent()).isEmpty();
+    }
+}

--- a/api/src/test/java/com/example/chat/service/SqsNotificationServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/SqsNotificationServiceTest.java
@@ -1,0 +1,100 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.model.entity.ChatMessage;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SqsNotificationServiceTest {
+
+    @Mock
+    private SqsTemplate sqsTemplate;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Test
+    void sendNotification_whenSqsConfigured_sendsToSqs() {
+        SqsNotificationService service = buildService(sqsTemplate, "chat-notifications");
+        ChatMessage message = buildMessage();
+
+        service.sendNotification(message);
+
+        verify(sqsTemplate).send(any(Consumer.class));
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void sendNotification_whenSqsTemplateIsNull_publishesLocalEvent() {
+        SqsNotificationService service = buildService(null, "chat-notifications");
+        ChatMessage message = buildMessage();
+
+        service.sendNotification(message);
+
+        verify(eventPublisher).publishEvent(any(ChatNotificationEvent.class));
+    }
+
+    @Test
+    void sendNotification_whenQueueNameIsBlank_publishesLocalEvent() {
+        SqsNotificationService service = buildService(sqsTemplate, "");
+        ChatMessage message = buildMessage();
+
+        service.sendNotification(message);
+
+        verify(eventPublisher).publishEvent(any(ChatNotificationEvent.class));
+        verify(sqsTemplate, never()).send(any(Consumer.class));
+    }
+
+    @Test
+    void sendNotification_eventHasCorrectFieldsMappedFromChatMessage() {
+        SqsNotificationService service = buildService(null, "");
+        ChatMessage message = buildMessage();
+
+        service.sendNotification(message);
+
+        ArgumentCaptor<ChatNotificationEvent> captor = ArgumentCaptor.forClass(ChatNotificationEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        ChatNotificationEvent event = captor.getValue();
+        assertThat(event.messageId()).isEqualTo(message.getId());
+        assertThat(event.roomId()).isEqualTo(message.getRoomId());
+        assertThat(event.senderId()).isEqualTo(message.getSenderId());
+        assertThat(event.senderName()).isEqualTo(message.getSenderName());
+        assertThat(event.content()).isEqualTo(message.getContent());
+        assertThat(event.messageType()).isEqualTo(message.getMessageType());
+        assertThat(event.createdAt()).isEqualTo(message.getCreatedAt());
+    }
+
+    @SuppressWarnings("unchecked")
+    private SqsNotificationService buildService(SqsTemplate template, String queueName) {
+        ObjectProvider<SqsTemplate> provider = mock(ObjectProvider.class);
+        lenient().when(provider.getIfAvailable()).thenReturn(template);
+        return new SqsNotificationService(provider, queueName, eventPublisher);
+    }
+
+    private ChatMessage buildMessage() {
+        ChatMessage msg = new ChatMessage();
+        msg.setId(UUID.randomUUID());
+        msg.setRoomId(UUID.randomUUID());
+        msg.setSenderId("user-42");
+        msg.setSenderName("Bob");
+        msg.setContent("Test message");
+        msg.setMessageType("TEXT");
+        msg.setCreatedAt(Instant.parse("2026-01-15T10:30:00Z"));
+        return msg;
+    }
+}

--- a/api/src/test/java/com/example/chat/service/UserServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/UserServiceTest.java
@@ -1,0 +1,124 @@
+package com.example.chat.service;
+
+import com.example.chat.model.entity.User;
+import com.example.chat.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void ensureUser_createsNewUserWhenNotExists() {
+        when(userRepository.findById("new-user")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.ensureUser("new-user", "alice@example.com");
+
+        assertThat(result.getId()).isEqualTo("new-user");
+        assertThat(result.getEmail()).isEqualTo("alice@example.com");
+        assertThat(result.getDisplayName()).isEqualTo("alice");
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getDisplayName()).isEqualTo("alice");
+    }
+
+    @Test
+    void ensureUser_returnsExistingUser() {
+        var existing = new User();
+        existing.setId("existing-user");
+        existing.setEmail("bob@example.com");
+        existing.setDisplayName("Bob");
+
+        when(userRepository.findById("existing-user")).thenReturn(Optional.of(existing));
+
+        User result = userService.ensureUser("existing-user", "bob@example.com");
+
+        assertThat(result.getId()).isEqualTo("existing-user");
+        assertThat(result.getDisplayName()).isEqualTo("Bob");
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void ensureUser_usesEmailPrefixAsDisplayName() {
+        when(userRepository.findById("user1")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User result = userService.ensureUser("user1", "john.doe@company.co.jp");
+
+        assertThat(result.getDisplayName()).isEqualTo("john.doe");
+    }
+
+    @Test
+    void getUser_returnsUserWhenFound() {
+        var user = new User();
+        user.setId("user1");
+        user.setEmail("test@example.com");
+        user.setDisplayName("Test");
+
+        when(userRepository.findById("user1")).thenReturn(Optional.of(user));
+
+        User result = userService.getUser("user1");
+
+        assertThat(result.getId()).isEqualTo("user1");
+        assertThat(result.getDisplayName()).isEqualTo("Test");
+    }
+
+    @Test
+    void getUser_throwsRuntimeExceptionWhenNotFound() {
+        when(userRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.getUser("missing"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found");
+    }
+
+    @Test
+    void searchUsers_delegatesToRepository() {
+        var user1 = new User();
+        user1.setId("u1");
+        user1.setDisplayName("Alice");
+
+        var user2 = new User();
+        user2.setId("u2");
+        user2.setDisplayName("Alicia");
+
+        when(userRepository.findByEmailContainingIgnoreCaseOrDisplayNameContainingIgnoreCase("ali", "ali"))
+                .thenReturn(List.of(user1, user2));
+
+        List<User> results = userService.searchUsers("ali");
+
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(User::getDisplayName).containsExactly("Alice", "Alicia");
+        verify(userRepository).findByEmailContainingIgnoreCaseOrDisplayNameContainingIgnoreCase("ali", "ali");
+    }
+
+    @Test
+    void searchUsers_returnsEmptyListWhenNoMatch() {
+        when(userRepository.findByEmailContainingIgnoreCaseOrDisplayNameContainingIgnoreCase("xyz", "xyz"))
+                .thenReturn(List.of());
+
+        List<User> results = userService.searchUsers("xyz");
+
+        assertThat(results).isEmpty();
+    }
+}

--- a/api/src/test/java/com/example/chat/service/WebPushServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/WebPushServiceTest.java
@@ -1,0 +1,147 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.model.entity.PushSubscription;
+import com.example.chat.model.entity.RoomMember;
+import com.example.chat.repository.PushSubscriptionRepository;
+import com.example.chat.repository.RoomMemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.martijndwars.webpush.PushService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WebPushServiceTest {
+
+    @Mock
+    private PushService pushService;
+
+    @Mock
+    private PushSubscriptionRepository pushSubscriptionRepository;
+
+    @Mock
+    private RoomMemberRepository roomMemberRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private WebPushService webPushService;
+
+    private static final UUID ROOM_ID = UUID.randomUUID();
+    private static final UUID MESSAGE_ID = UUID.randomUUID();
+    private static final String SENDER_ID = "sender-001";
+    private static final String SENDER_NAME = "Alice";
+    private static final Instant CREATED_AT = Instant.parse("2026-01-15T10:30:00Z");
+
+    @BeforeEach
+    void setUp() {
+        webPushService = createServiceWithPushService(pushService);
+    }
+
+    @Test
+    void whenPushServiceIsNullDoesNothing() {
+        webPushService = createServiceWithPushService(null);
+
+        webPushService.sendPushToMembers(createEvent("Hello"));
+
+        verifyNoInteractions(roomMemberRepository);
+        verifyNoInteractions(pushSubscriptionRepository);
+    }
+
+    @Test
+    void lookupSubscriptionsForAllMembersExceptSender() {
+        var members = List.of(
+                createMember(SENDER_ID, "Alice"),
+                createMember("user-002", "Bob"),
+                createMember("user-003", "Charlie"));
+        when(roomMemberRepository.findByRoomId(ROOM_ID)).thenReturn(members);
+        when(pushSubscriptionRepository.findByUserId("user-002")).thenReturn(List.of());
+        when(pushSubscriptionRepository.findByUserId("user-003")).thenReturn(List.of());
+
+        webPushService.sendPushToMembers(createEvent("Hello"));
+
+        verify(pushSubscriptionRepository).findByUserId("user-002");
+        verify(pushSubscriptionRepository).findByUserId("user-003");
+        verify(pushSubscriptionRepository, never()).findByUserId(SENDER_ID);
+    }
+
+    @Test
+    void doesNotSendPushToSenderSubscriptions() {
+        var members = List.of(
+                createMember(SENDER_ID, "Alice"),
+                createMember("user-002", "Bob"));
+        when(roomMemberRepository.findByRoomId(ROOM_ID)).thenReturn(members);
+        when(pushSubscriptionRepository.findByUserId("user-002")).thenReturn(List.of());
+
+        webPushService.sendPushToMembers(createEvent("Hello"));
+
+        verify(pushSubscriptionRepository, never()).findByUserId(SENDER_ID);
+    }
+
+    @Test
+    void handlesExceptionGracefullyWhenSubscriptionExists() {
+        var members = List.of(createMember("user-002", "Bob"));
+        when(roomMemberRepository.findByRoomId(ROOM_ID)).thenReturn(members);
+
+        var sub = createSubscription("user-002", "https://push.example.com/error");
+        when(pushSubscriptionRepository.findByUserId("user-002")).thenReturn(List.of(sub));
+
+        assertThatNoException().isThrownBy(
+                () -> webPushService.sendPushToMembers(createEvent("Hello")));
+    }
+
+    @Test
+    void worksWithEmptyMemberList() {
+        when(roomMemberRepository.findByRoomId(ROOM_ID)).thenReturn(List.of());
+
+        assertThatNoException().isThrownBy(
+                () -> webPushService.sendPushToMembers(createEvent("Hello")));
+
+        verifyNoInteractions(pushSubscriptionRepository);
+    }
+
+    private WebPushService createServiceWithPushService(PushService ps) {
+        @SuppressWarnings("unchecked")
+        ObjectProvider<PushService> provider = mock(ObjectProvider.class);
+        lenient().when(provider.getIfAvailable()).thenReturn(ps);
+        return new WebPushService(provider, pushSubscriptionRepository,
+                roomMemberRepository, objectMapper);
+    }
+
+    private ChatNotificationEvent createEvent(String content) {
+        return new ChatNotificationEvent(
+                MESSAGE_ID, ROOM_ID, SENDER_ID, SENDER_NAME,
+                content, "TEXT", CREATED_AT);
+    }
+
+    private RoomMember createMember(String userId, String userName) {
+        var member = new RoomMember();
+        member.setRoomId(ROOM_ID);
+        member.setUserId(userId);
+        member.setUserName(userName);
+        member.setRole("MEMBER");
+        member.setJoinedAt(Instant.now());
+        return member;
+    }
+
+    private PushSubscription createSubscription(String userId, String endpoint) {
+        var sub = new PushSubscription();
+        sub.setId(UUID.randomUUID());
+        sub.setUserId(userId);
+        sub.setEndpoint(endpoint);
+        sub.setP256dh("test-p256dh");
+        sub.setAuth("test-auth");
+        sub.setCreatedAt(Instant.now());
+        return sub;
+    }
+}

--- a/api/src/test/resources/application-test.yaml
+++ b/api/src/test/resources/application-test.yaml
@@ -1,0 +1,33 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+  flyway:
+    enabled: true
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://cognito-idp.ap-northeast-1.amazonaws.com/placeholder
+  autoconfigure:
+    exclude:
+      - io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration
+      - io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration
+      - io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration
+      - io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveElasticsearchRepositoriesAutoConfiguration
+      - org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration
+      - org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration
+
+app:
+  s3:
+    bucket: test-bucket
+  sqs:
+    queue-url: ""
+    chat-message-queue: ""
+  webpush:
+    vapid-public-key: ""
+    vapid-private-key: ""

--- a/api/src/test/resources/testcontainers.properties
+++ b/api/src/test/resources/testcontainers.properties
@@ -1,0 +1,2 @@
+docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy
+dockerApiVersion=1.43

--- a/web/e2e/smoke.test.ts
+++ b/web/e2e/smoke.test.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Smoke tests', () => {
+	test('login page renders with form elements', async ({ page }) => {
+		await page.goto('/login');
+
+		// Title
+		await expect(page.locator('text=Chat')).toBeVisible();
+
+		// Login tab and signup tab
+		await expect(page.getByRole('tab', { name: 'ログイン' })).toBeVisible();
+		await expect(page.getByRole('tab', { name: 'サインアップ' })).toBeVisible();
+
+		// Email and password inputs
+		await expect(page.getByPlaceholder('メールアドレス')).toBeVisible();
+		await expect(page.getByPlaceholder('パスワード')).toBeVisible();
+
+		// Submit button
+		await expect(page.getByRole('button', { name: 'ログイン' })).toBeVisible();
+	});
+
+	test('login page has correct page title', async ({ page }) => {
+		await page.goto('/login');
+		await expect(page).toHaveTitle('Chat');
+	});
+
+	test('unauthenticated user is redirected to /login from root', async ({ page }) => {
+		await page.goto('/');
+		await page.waitForURL('/login');
+		expect(page.url()).toContain('/login');
+	});
+
+	test('unauthenticated user is redirected to /login from /rooms', async ({ page }) => {
+		await page.goto('/rooms');
+		await page.waitForURL('/login');
+		expect(page.url()).toContain('/login');
+	});
+
+	test('unauthenticated user is redirected to /login from /friends', async ({ page }) => {
+		await page.goto('/friends');
+		await page.waitForURL('/login');
+		expect(page.url()).toContain('/login');
+	});
+
+	test('login page signup tab switches form button text', async ({ page }) => {
+		await page.goto('/login');
+
+		await page.getByRole('tab', { name: 'サインアップ' }).click();
+		await expect(page.getByRole('button', { name: 'サインアップ' })).toBeVisible();
+
+		await page.getByRole('tab', { name: 'ログイン' }).click();
+		await expect(page.getByRole('button', { name: 'ログイン' })).toBeVisible();
+	});
+
+	test('favicon loads successfully', async ({ page }) => {
+		await page.goto('/login');
+		const favicon = page.locator('link[rel="icon"]');
+		const href = await favicon.getAttribute('href');
+		expect(href).toBeTruthy();
+
+		if (href) {
+			const response = await page.request.get(href);
+			expect(response.ok()).toBe(true);
+		}
+	});
+
+	test('dark mode class is applied to html element', async ({ page }) => {
+		await page.goto('/login');
+		await expect(page.locator('html')).toHaveClass(/dark/);
+	});
+});

--- a/web/package.json
+++ b/web/package.json
@@ -9,20 +9,26 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test": "vitest run",
+		"test:e2e": "playwright test"
 	},
 	"devDependencies": {
 		"@fontsource-variable/figtree": "^5.2.10",
 		"@hugeicons/core-free-icons": "^4.0.0",
 		"@hugeicons/svelte": "^1.1.2",
 		"@internationalized/date": "^3.12.0",
+		"@playwright/test": "^1.59.0",
 		"@sveltejs/adapter-auto": "latest",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "latest",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/vite": "^4.2.2",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/svelte": "^5.3.1",
 		"bits-ui": "^2.16.4",
 		"clsx": "^2.1.1",
+		"jsdom": "^29.0.1",
 		"svelte": "^5.54.0",
 		"svelte-check": "^4.4.2",
 		"tailwind-merge": "^3.5.0",
@@ -30,7 +36,8 @@
 		"tailwindcss": "^4.2.2",
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5.9.3",
-		"vite": "^7.3.1"
+		"vite": "^7.3.1",
+		"vitest": "^4.1.2"
 	},
 	"dependencies": {
 		"@stomp/stompjs": "^7.3.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+	testDir: 'e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		baseURL: 'http://localhost:4173',
+		trace: 'on-first-retry'
+	},
+	webServer: {
+		command: 'pnpm preview',
+		port: 4173,
+		reuseExistingServer: !process.env.CI
+	}
+});

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@internationalized/date':
         specifier: ^3.12.0
         version: 3.12.0
+      '@playwright/test':
+        specifier: ^1.59.0
+        version: 1.59.0
       '@sveltejs/adapter-auto':
         specifier: latest
         version: 7.0.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)))
@@ -42,12 +45,21 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/svelte':
+        specifier: ^5.3.1
+        version: 5.3.1(svelte@5.55.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0))(vitest@4.1.2(jsdom@29.0.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)))
       bits-ui:
         specifier: ^2.16.4
         version: 2.16.4(@internationalized/date@3.12.0)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
       svelte:
         specifier: ^5.54.0
         version: 5.55.0
@@ -72,8 +84,25 @@ importers:
       vite:
         specifier: ^7.3.1
         version: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(jsdom@29.0.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0))
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@5.1.1':
+    resolution: {integrity: sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    resolution: {integrity: sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@aws-crypto/sha256-js@1.2.2':
     resolution: {integrity: sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==}
@@ -87,6 +116,58 @@ packages:
 
   '@aws-sdk/util-utf8-browser@3.259.0':
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -244,6 +325,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -282,6 +372,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@playwright/test@1.59.0':
+    resolution: {integrity: sha512-TOA5sTLd49rTDaZpYpvCQ9hGefHQq/OYOyCVnGqS2mjMfX+lGZv2iddIJd0I48cfxqSPttS9S3OuLKyylHcO1w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -577,8 +672,44 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/svelte-core@1.0.0':
+    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.3.1':
+    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -590,6 +721,35 @@ packages:
     resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -598,9 +758,24 @@ packages:
   amazon-cognito-identity-js@6.3.16:
     resolution: {integrity: sha512-HPGSBGD6Q36t99puWh0LnptxO/4icnk2kqIQ9cTJ2tFQo5NMUnWQIgtrTAk8nm+caqUbjDzXzG56GBjI2tS6jQ==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -608,6 +783,9 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bits-ui@2.16.4:
     resolution: {integrity: sha512-76dKbW0DGplG7qnVM3kljE2CmCXqh9tj9OfVo0DvC/ZGRkZNJ/auU/aQnMKBxDnSqRvsz2mZBccBkUKyF4/SoQ==}
@@ -619,6 +797,10 @@ packages:
   buffer@4.9.2:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -627,9 +809,26 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -646,9 +845,22 @@ packages:
   devalue@5.6.4:
     resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -660,6 +872,13 @@ packages:
 
   esrap@2.2.4:
     resolution: {integrity: sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-base64-decode@1.0.0:
     resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
@@ -673,6 +892,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -681,11 +905,22 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
@@ -702,6 +937,18 @@ packages:
 
   js-cookie@2.2.1:
     resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -784,12 +1031,23 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -816,6 +1074,12 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -823,13 +1087,42 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  playwright-core@1.59.0:
+    resolution: {integrity: sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.0:
+    resolution: {integrity: sha512-wihGScriusvATUxmhfENxg0tj1vHEFeIwxlnPFKQTOQVd7aG08mUfvvniRP/PtQOC+2Bs52kBOC/Up1jTXeIbw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   rollup@4.60.0:
     resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
@@ -849,8 +1142,15 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -859,6 +1159,16 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
@@ -880,6 +1190,9 @@ packages:
   svelte@5.55.0:
     resolution: {integrity: sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw==}
     engines: {node: '>=18'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -904,16 +1217,42 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.27:
+    resolution: {integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==}
+
+  tldts@7.0.27:
+    resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
+    hasBin: true
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -928,6 +1267,10 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
@@ -980,16 +1323,99 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@5.1.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@aws-crypto/sha256-js@1.2.2':
     dependencies:
@@ -1011,6 +1437,44 @@ snapshots:
   '@aws-sdk/util-utf8-browser@3.259.0':
     dependencies:
       tslib: 2.8.1
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
@@ -1090,6 +1554,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
+  '@exodus/bytes@1.15.0': {}
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -1131,6 +1597,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@playwright/test@1.59.0':
+    dependencies:
+      playwright: 1.59.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -1338,13 +1808,96 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.1
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/svelte-core@1.0.0(svelte@5.55.0)':
+    dependencies:
+      svelte: 5.55.0
+
+  '@testing-library/svelte@5.3.1(svelte@5.55.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0))(vitest@4.1.2(jsdom@29.0.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)))':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/svelte-core': 1.0.0(svelte@5.55.0)
+      svelte: 5.55.0
+    optionalDependencies:
+      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)
+      vitest: 4.1.2(jsdom@29.0.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0))
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cookie@0.6.0': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
   '@types/trusted-types@2.0.7': {}
 
   '@typescript-eslint/types@8.57.2': {}
+
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.2': {}
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   acorn@8.16.0: {}
 
@@ -1358,11 +1911,25 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   aria-query@5.3.1: {}
+
+  assertion-error@2.0.1: {}
 
   axobject-query@4.1.0: {}
 
   base64-js@1.5.1: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bits-ui@2.16.4(@internationalized/date@3.12.0)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.0)(typescript@5.9.3)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.0):
     dependencies:
@@ -1383,13 +1950,33 @@ snapshots:
       ieee754: 1.2.1
       isarray: 1.0.0
 
+  chai@6.2.2: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
 
   clsx@2.1.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie@0.6.0: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  decimal.js@10.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -1399,10 +1986,18 @@ snapshots:
 
   devalue@5.6.4: {}
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@6.0.1: {}
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -1440,20 +2035,39 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@typescript-eslint/types': 8.57.2
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
   fast-base64-decode@1.0.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
   graceful-fs@4.2.11: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   ieee754@1.2.1: {}
 
+  indent-string@4.0.0: {}
+
   inline-style-parser@0.2.7: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -1471,6 +2085,34 @@ snapshots:
   jiti@2.6.1: {}
 
   js-cookie@2.2.1: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@29.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.1
+      '@asamuzakjp/dom-selector': 7.0.4
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   kleur@4.1.5: {}
 
@@ -1525,11 +2167,17 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  lru-cache@11.2.7: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
+
+  min-indent@1.0.1: {}
 
   mri@1.2.0: {}
 
@@ -1543,9 +2191,23 @@ snapshots:
 
   obug@2.1.1: {}
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.0: {}
+
+  playwright@1.59.0:
+    dependencies:
+      playwright-core: 1.59.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.8:
     dependencies:
@@ -1553,7 +2215,24 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
+  react-is@17.0.2: {}
+
   readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  require-from-string@2.0.2: {}
 
   rollup@4.60.0:
     dependencies:
@@ -1599,7 +2278,13 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   set-cookie-parser@3.1.0: {}
+
+  siginfo@2.0.0: {}
 
   sirv@3.0.2:
     dependencies:
@@ -1608,6 +2293,14 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   style-to-object@1.0.14:
     dependencies:
@@ -1653,6 +2346,8 @@ snapshots:
       magic-string: 0.30.21
       zimmerframe: 1.1.4
 
+  symbol-tree@3.2.4: {}
+
   tabbable@6.4.0: {}
 
   tailwind-merge@3.5.0: {}
@@ -1667,14 +2362,34 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.27: {}
+
+  tldts@7.0.27:
+    dependencies:
+      tldts-core: 7.0.27
+
   totalist@3.0.1: {}
 
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.27
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@1.14.1: {}
 
@@ -1683,6 +2398,8 @@ snapshots:
   tw-animate-css@1.4.0: {}
 
   typescript@5.9.3: {}
+
+  undici@7.24.7: {}
 
   unfetch@4.2.0: {}
 
@@ -1703,11 +2420,63 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)
 
+  vitest@4.1.2(jsdom@29.0.1)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 29.0.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   zimmerframe@1.1.4: {}

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+	getAuthState: vi.fn()
+}));
+
+import {
+	createRoom,
+	listRooms,
+	getRoom,
+	joinRoom,
+	leaveRoom,
+	getMessages,
+	getUnreadCounts,
+	clearUnreadCount
+} from './api';
+import { getAuthState } from '$lib/stores/auth.svelte';
+
+let mockFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+	vi.restoreAllMocks();
+	mockFetch = vi.fn();
+	vi.stubGlobal('fetch', mockFetch);
+});
+
+function mockJsonResponse(data: unknown, status = 200) {
+	return mockFetch.mockResolvedValue({
+		ok: true,
+		status,
+		json: () => Promise.resolve(data),
+		text: () => Promise.resolve(JSON.stringify(data))
+	});
+}
+
+function mockNoContentResponse() {
+	return mockFetch.mockResolvedValue({
+		ok: true,
+		status: 204,
+		json: () => Promise.resolve(undefined),
+		text: () => Promise.resolve('')
+	});
+}
+
+function mockErrorResponse(status: number, body = '') {
+	return mockFetch.mockResolvedValue({
+		ok: false,
+		status,
+		statusText: 'Not Found',
+		text: () => Promise.resolve(body)
+	});
+}
+
+describe('api client', () => {
+	describe('request internals', () => {
+		it('adds Authorization header when token exists', async () => {
+			vi.mocked(getAuthState).mockReturnValue({
+				user: { sub: 'u1', email: 'a@b.com' },
+				token: 'my-jwt-token',
+				isAuthenticated: true,
+				loading: false
+			});
+			mockJsonResponse([]);
+
+			await listRooms();
+
+			expect(mockFetch).toHaveBeenCalledWith('/api/rooms', {
+				method: 'GET',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: 'Bearer my-jwt-token'
+				},
+				body: undefined
+			});
+		});
+
+		it('omits Authorization header when no token', async () => {
+			vi.mocked(getAuthState).mockReturnValue({
+				user: null,
+				token: null,
+				isAuthenticated: false,
+				loading: false
+			});
+			mockJsonResponse([]);
+
+			await listRooms();
+
+			const headers = mockFetch.mock.calls[0][1].headers;
+			expect(headers).not.toHaveProperty('Authorization');
+		});
+
+		it('throws on non-ok response with error body', async () => {
+			vi.mocked(getAuthState).mockReturnValue({
+				user: null, token: 'tok', isAuthenticated: true, loading: false
+			});
+			mockErrorResponse(404, 'Room not found');
+
+			await expect(listRooms()).rejects.toThrow('Room not found');
+		});
+
+		it('throws with status text when error body is empty', async () => {
+			vi.mocked(getAuthState).mockReturnValue({
+				user: null, token: 'tok', isAuthenticated: true, loading: false
+			});
+			mockErrorResponse(404);
+
+			await expect(listRooms()).rejects.toThrow('404 Not Found');
+		});
+
+		it('handles 204 No Content response', async () => {
+			vi.mocked(getAuthState).mockReturnValue({
+				user: null, token: 'tok', isAuthenticated: true, loading: false
+			});
+			mockNoContentResponse();
+
+			const result = await joinRoom('room-1');
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('API functions', () => {
+		beforeEach(() => {
+			vi.mocked(getAuthState).mockReturnValue({
+				user: null, token: 'tok', isAuthenticated: true, loading: false
+			});
+		});
+
+		it('createRoom sends POST with name and description', async () => {
+			const room = { id: 'r1', name: 'Test', description: 'Desc', createdBy: 'u1', createdAt: '', memberCount: 1 };
+			mockJsonResponse(room);
+
+			const result = await createRoom('Test', 'Desc');
+
+			expect(result).toEqual(room);
+			expect(mockFetch).toHaveBeenCalledWith('/api/rooms', expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify({ name: 'Test', description: 'Desc' })
+			}));
+		});
+
+		it('listRooms sends GET to /api/rooms', async () => {
+			mockJsonResponse([]);
+
+			const result = await listRooms();
+
+			expect(result).toEqual([]);
+			expect(mockFetch).toHaveBeenCalledWith('/api/rooms', expect.objectContaining({
+				method: 'GET'
+			}));
+		});
+
+		it('getRoom sends GET with roomId', async () => {
+			const room = { id: 'r1', name: 'Test', description: '', createdBy: 'u1', createdAt: '', memberCount: 1 };
+			mockJsonResponse(room);
+
+			const result = await getRoom('r1');
+
+			expect(result).toEqual(room);
+			expect(mockFetch).toHaveBeenCalledWith('/api/rooms/r1', expect.objectContaining({ method: 'GET' }));
+		});
+
+		it('leaveRoom sends DELETE', async () => {
+			mockNoContentResponse();
+
+			await leaveRoom('r1');
+
+			expect(mockFetch).toHaveBeenCalledWith('/api/rooms/r1/leave', expect.objectContaining({ method: 'DELETE' }));
+		});
+
+		it('getMessages sends GET with pagination params', async () => {
+			const page = { content: [], totalPages: 0, totalElements: 0, number: 0 };
+			mockJsonResponse(page);
+
+			await getMessages('r1', 2, 25);
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				'/api/rooms/r1/messages?page=2&size=25',
+				expect.objectContaining({ method: 'GET' })
+			);
+		});
+
+		it('getUnreadCounts sends GET to /api/notifications/unread', async () => {
+			mockJsonResponse({ 'room-1': 5 });
+
+			const result = await getUnreadCounts();
+
+			expect(result).toEqual({ 'room-1': 5 });
+			expect(mockFetch).toHaveBeenCalledWith('/api/notifications/unread', expect.objectContaining({ method: 'GET' }));
+		});
+
+		it('clearUnreadCount sends DELETE with roomId', async () => {
+			mockNoContentResponse();
+
+			await clearUnreadCount('room-1');
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				'/api/notifications/unread/room-1',
+				expect.objectContaining({ method: 'DELETE' })
+			);
+		});
+	});
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -103,3 +103,20 @@ export const acceptFriendRequest = (userId: string) =>
 
 export const removeFriend = (userId: string) =>
 	request<void>('DELETE', `/api/friends/${userId}`);
+
+// Notifications
+export const getUnreadCounts = () =>
+	request<Record<string, number>>('GET', '/api/notifications/unread');
+
+export const clearUnreadCount = (roomId: string) =>
+	request<void>('DELETE', `/api/notifications/unread/${roomId}`);
+
+// Push
+export const getVapidKey = () =>
+	request<{ publicKey: string }>('GET', '/api/push/vapid-key');
+
+export const subscribePush = (endpoint: string, p256dh: string, auth: string) =>
+	request<void>('POST', '/api/push/subscribe', { endpoint, p256dh, auth });
+
+export const unsubscribePush = (endpoint: string) =>
+	request<void>('DELETE', '/api/push/unsubscribe', { endpoint });

--- a/web/src/lib/components/Toast.svelte
+++ b/web/src/lib/components/Toast.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { getNotificationState, dismissToast } from '$lib/stores/notifications.svelte';
+
+	const notifications = getNotificationState();
+</script>
+
+{#if notifications.toasts.length > 0}
+	<div class="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+		{#each notifications.toasts as toast (toast.id)}
+			<button
+				onclick={() => { dismissToast(toast.id); goto(`/rooms/${toast.roomId}`); }}
+				class="w-72 rounded-lg border border-border bg-card p-3 shadow-lg transition hover:bg-muted text-left"
+			>
+				<p class="text-xs font-medium text-primary">{toast.senderName}</p>
+				<p class="mt-1 truncate text-sm text-foreground">{toast.contentPreview}</p>
+			</button>
+		{/each}
+	</div>
+{/if}

--- a/web/src/lib/push.test.ts
+++ b/web/src/lib/push.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/api', () => ({
+	getVapidKey: vi.fn(),
+	subscribePush: vi.fn()
+}));
+
+import { initPushNotifications } from './push';
+import { getVapidKey, subscribePush } from '$lib/api';
+
+function createMockRegistration(existingSubscription: unknown = null) {
+	const mockSubscription = {
+		endpoint: 'https://push.example.com/abc',
+		toJSON: () => ({
+			endpoint: 'https://push.example.com/abc',
+			keys: { p256dh: 'p256dh-key', auth: 'auth-key' }
+		})
+	};
+
+	return {
+		pushManager: {
+			getSubscription: vi.fn().mockResolvedValue(existingSubscription),
+			subscribe: vi.fn().mockResolvedValue(mockSubscription)
+		}
+	};
+}
+
+function setupServiceWorker(reg: ReturnType<typeof createMockRegistration>) {
+	const swMock = {
+		register: vi.fn().mockResolvedValue(reg),
+		ready: Promise.resolve(reg)
+	};
+	Object.defineProperty(navigator, 'serviceWorker', {
+		value: swMock,
+		writable: true,
+		configurable: true
+	});
+}
+
+describe('push notifications', () => {
+	let mockRegistration: ReturnType<typeof createMockRegistration>;
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.clearAllMocks();
+		mockRegistration = createMockRegistration();
+		setupServiceWorker(mockRegistration);
+
+		// Mock PushManager
+		vi.stubGlobal('PushManager', class {});
+
+		vi.mocked(getVapidKey).mockResolvedValue({ publicKey: 'BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkOs-WLLo-0' });
+		vi.mocked(subscribePush).mockResolvedValue(undefined);
+	});
+
+	it('skips if serviceWorker is not supported', async () => {
+		Object.defineProperty(navigator, 'serviceWorker', {
+			value: undefined,
+			writable: true,
+			configurable: true
+		});
+
+		await initPushNotifications();
+
+		expect(getVapidKey).not.toHaveBeenCalled();
+	});
+
+	it('skips if PushManager is not supported', async () => {
+		// @ts-expect-error - removing PushManager for test
+		delete window.PushManager;
+
+		await initPushNotifications();
+
+		expect(getVapidKey).not.toHaveBeenCalled();
+	});
+
+	it('registers service worker at /sw.js', async () => {
+		await initPushNotifications();
+
+		expect(navigator.serviceWorker.register).toHaveBeenCalledWith('/sw.js');
+	});
+
+	it('skips if already subscribed', async () => {
+		const existingSub = { endpoint: 'https://existing.com' };
+		mockRegistration = createMockRegistration(existingSub);
+		setupServiceWorker(mockRegistration);
+
+		await initPushNotifications();
+
+		expect(getVapidKey).not.toHaveBeenCalled();
+		expect(subscribePush).not.toHaveBeenCalled();
+	});
+
+	it('subscribes and sends keys to backend', async () => {
+		await initPushNotifications();
+
+		expect(mockRegistration.pushManager.subscribe).toHaveBeenCalledWith({
+			userVisibleOnly: true,
+			applicationServerKey: expect.any(Uint8Array)
+		});
+		expect(subscribePush).toHaveBeenCalledWith(
+			'https://push.example.com/abc',
+			'p256dh-key',
+			'auth-key'
+		);
+	});
+
+	it('skips backend call if publicKey is empty', async () => {
+		mockRegistration = createMockRegistration();
+		setupServiceWorker(mockRegistration);
+		vi.mocked(getVapidKey).mockResolvedValue({ publicKey: '' });
+
+		await initPushNotifications();
+
+		expect(mockRegistration.pushManager.subscribe).not.toHaveBeenCalled();
+		expect(subscribePush).not.toHaveBeenCalled();
+	});
+
+	it('skips backend call if subscription keys are missing', async () => {
+		const noKeysSub = {
+			endpoint: 'https://push.example.com/abc',
+			toJSON: () => ({ endpoint: 'https://push.example.com/abc' })
+		};
+		mockRegistration = createMockRegistration();
+		mockRegistration.pushManager.subscribe.mockResolvedValue(noKeysSub);
+		setupServiceWorker(mockRegistration);
+
+		await initPushNotifications();
+
+		expect(subscribePush).not.toHaveBeenCalled();
+	});
+
+	it('logs error and does not throw on failure', async () => {
+		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.mocked(getVapidKey).mockRejectedValue(new Error('network'));
+
+		await expect(initPushNotifications()).resolves.toBeUndefined();
+		expect(consoleSpy).toHaveBeenCalledWith('Push notification setup failed:', expect.any(Error));
+	});
+});

--- a/web/src/lib/push.ts
+++ b/web/src/lib/push.ts
@@ -1,0 +1,36 @@
+import { getVapidKey, subscribePush } from '$lib/api';
+
+export async function initPushNotifications(): Promise<void> {
+	if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+
+	try {
+		const registration = await navigator.serviceWorker.register('/sw.js');
+		await navigator.serviceWorker.ready;
+
+		const existing = await registration.pushManager.getSubscription();
+		if (existing) return;
+
+		const { publicKey } = await getVapidKey();
+		if (!publicKey) return;
+
+		const applicationServerKey = urlBase64ToUint8Array(publicKey);
+		const subscription = await registration.pushManager.subscribe({
+			userVisibleOnly: true,
+			applicationServerKey
+		});
+
+		const json = subscription.toJSON();
+		if (json.endpoint && json.keys?.p256dh && json.keys?.auth) {
+			await subscribePush(json.endpoint, json.keys.p256dh, json.keys.auth);
+		}
+	} catch (e) {
+		console.error('Push notification setup failed:', e);
+	}
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+	const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+	const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+	const rawData = atob(base64);
+	return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
+}

--- a/web/src/lib/stores/notifications.svelte.ts
+++ b/web/src/lib/stores/notifications.svelte.ts
@@ -1,0 +1,78 @@
+import { getUnreadCounts, clearUnreadCount } from '$lib/api';
+
+export interface NotificationPayload {
+	roomId: string;
+	messageId: string;
+	senderName: string;
+	contentPreview: string;
+	messageType: string;
+	createdAt: string;
+}
+
+export interface Toast {
+	id: string;
+	roomId: string;
+	senderName: string;
+	contentPreview: string;
+	timestamp: number;
+}
+
+let currentRoomId = $state<string | null>(null);
+let unreadCounts = $state<Record<string, number>>({});
+let toasts = $state<Toast[]>([]);
+
+export function getNotificationState() {
+	return {
+		get currentRoomId() { return currentRoomId; },
+		get unreadCounts() { return unreadCounts; },
+		get toasts() { return toasts; }
+	};
+}
+
+export function setCurrentRoom(roomId: string | null) {
+	currentRoomId = roomId;
+}
+
+export function handleNotification(payload: NotificationPayload) {
+	if (payload.roomId === currentRoomId) return;
+
+	unreadCounts = {
+		...unreadCounts,
+		[payload.roomId]: (unreadCounts[payload.roomId] || 0) + 1
+	};
+
+	const toast: Toast = {
+		id: payload.messageId || crypto.randomUUID(),
+		roomId: payload.roomId,
+		senderName: payload.senderName,
+		contentPreview: payload.contentPreview,
+		timestamp: Date.now()
+	};
+	toasts = [...toasts, toast];
+
+	setTimeout(() => {
+		dismissToast(toast.id);
+	}, 5000);
+}
+
+export function dismissToast(id: string) {
+	toasts = toasts.filter((t) => t.id !== id);
+}
+
+export async function clearUnread(roomId: string) {
+	const { [roomId]: _, ...rest } = unreadCounts;
+	unreadCounts = rest;
+	try {
+		await clearUnreadCount(roomId);
+	} catch {
+		// ignore
+	}
+}
+
+export async function loadUnreadCounts() {
+	try {
+		unreadCounts = await getUnreadCounts();
+	} catch {
+		// ignore
+	}
+}

--- a/web/src/lib/stores/notifications.test.ts
+++ b/web/src/lib/stores/notifications.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/api', () => ({
+	getUnreadCounts: vi.fn(),
+	clearUnreadCount: vi.fn()
+}));
+
+import {
+	getNotificationState,
+	setCurrentRoom,
+	handleNotification,
+	dismissToast,
+	clearUnread,
+	loadUnreadCounts,
+	type NotificationPayload
+} from './notifications.svelte';
+import { getUnreadCounts, clearUnreadCount } from '$lib/api';
+
+function makePayload(overrides: Partial<NotificationPayload> = {}): NotificationPayload {
+	return {
+		roomId: 'room-1',
+		messageId: 'msg-1',
+		senderName: 'Alice',
+		contentPreview: 'Hello!',
+		messageType: 'TEXT',
+		createdAt: '2026-01-01T00:00:00Z',
+		...overrides
+	};
+}
+
+describe('notifications store', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.restoreAllMocks();
+
+		// Reset store state
+		setCurrentRoom(null);
+		const state = getNotificationState();
+		// Clear toasts by dismissing all
+		for (const t of [...state.toasts]) {
+			dismissToast(t.id);
+		}
+		// Clear unread counts by calling clearUnread for each key
+		// We need to reset the module-level state; simplest way is to clear via exported functions
+		for (const roomId of Object.keys(state.unreadCounts)) {
+			// clearUnread is async but we just need the sync side-effect
+			clearUnread(roomId);
+		}
+	});
+
+	describe('handleNotification', () => {
+		it('adds a toast and increments unread count', () => {
+			handleNotification(makePayload());
+
+			const state = getNotificationState();
+			expect(state.unreadCounts['room-1']).toBe(1);
+			expect(state.toasts).toHaveLength(1);
+			expect(state.toasts[0].senderName).toBe('Alice');
+			expect(state.toasts[0].contentPreview).toBe('Hello!');
+			expect(state.toasts[0].roomId).toBe('room-1');
+		});
+
+		it('increments unread count on multiple notifications for same room', () => {
+			handleNotification(makePayload({ messageId: 'msg-1' }));
+			handleNotification(makePayload({ messageId: 'msg-2' }));
+			handleNotification(makePayload({ messageId: 'msg-3' }));
+
+			const state = getNotificationState();
+			expect(state.unreadCounts['room-1']).toBe(3);
+			expect(state.toasts).toHaveLength(3);
+		});
+
+		it('ignores notifications for the current room', () => {
+			setCurrentRoom('room-1');
+			handleNotification(makePayload({ roomId: 'room-1' }));
+
+			const state = getNotificationState();
+			expect(state.unreadCounts['room-1']).toBeUndefined();
+			expect(state.toasts).toHaveLength(0);
+		});
+
+		it('auto-dismisses toast after 5 seconds', () => {
+			handleNotification(makePayload());
+
+			const state = getNotificationState();
+			expect(state.toasts).toHaveLength(1);
+
+			vi.advanceTimersByTime(5000);
+			expect(state.toasts).toHaveLength(0);
+		});
+
+		it('uses crypto.randomUUID when messageId is empty', () => {
+			const mockUUID = '00000000-0000-0000-0000-000000000000';
+			vi.stubGlobal('crypto', { randomUUID: () => mockUUID });
+
+			handleNotification(makePayload({ messageId: '' }));
+
+			const state = getNotificationState();
+			expect(state.toasts[0].id).toBe(mockUUID);
+		});
+	});
+
+	describe('setCurrentRoom', () => {
+		it('sets the current room ID', () => {
+			setCurrentRoom('room-42');
+			expect(getNotificationState().currentRoomId).toBe('room-42');
+		});
+
+		it('can set room to null', () => {
+			setCurrentRoom('room-42');
+			setCurrentRoom(null);
+			expect(getNotificationState().currentRoomId).toBeNull();
+		});
+	});
+
+	describe('clearUnread', () => {
+		it('removes unread count for the room and calls API', async () => {
+			vi.mocked(clearUnreadCount).mockResolvedValue(undefined);
+
+			handleNotification(makePayload({ roomId: 'room-1' }));
+			expect(getNotificationState().unreadCounts['room-1']).toBe(1);
+
+			await clearUnread('room-1');
+			expect(getNotificationState().unreadCounts['room-1']).toBeUndefined();
+			expect(clearUnreadCount).toHaveBeenCalledWith('room-1');
+		});
+
+		it('removes count even if API call fails', async () => {
+			vi.mocked(clearUnreadCount).mockRejectedValue(new Error('network error'));
+
+			handleNotification(makePayload({ roomId: 'room-1' }));
+			await clearUnread('room-1');
+
+			expect(getNotificationState().unreadCounts['room-1']).toBeUndefined();
+		});
+	});
+
+	describe('dismissToast', () => {
+		it('removes the toast with matching id', () => {
+			handleNotification(makePayload({ messageId: 'msg-a' }));
+			handleNotification(makePayload({ messageId: 'msg-b', roomId: 'room-2' }));
+
+			const state = getNotificationState();
+			expect(state.toasts).toHaveLength(2);
+
+			dismissToast('msg-a');
+			expect(state.toasts).toHaveLength(1);
+			expect(state.toasts[0].id).toBe('msg-b');
+		});
+
+		it('does nothing if toast id not found', () => {
+			handleNotification(makePayload());
+			dismissToast('nonexistent');
+			expect(getNotificationState().toasts).toHaveLength(1);
+		});
+	});
+
+	describe('loadUnreadCounts', () => {
+		it('loads unread counts from API', async () => {
+			vi.mocked(getUnreadCounts).mockResolvedValue({ 'room-1': 5, 'room-2': 3 });
+
+			await loadUnreadCounts();
+
+			const state = getNotificationState();
+			expect(state.unreadCounts).toEqual({ 'room-1': 5, 'room-2': 3 });
+		});
+
+		it('keeps existing counts if API call fails', async () => {
+			handleNotification(makePayload({ roomId: 'room-1' }));
+			vi.mocked(getUnreadCounts).mockRejectedValue(new Error('network error'));
+
+			await loadUnreadCounts();
+
+			expect(getNotificationState().unreadCounts['room-1']).toBe(1);
+		});
+	});
+});

--- a/web/src/lib/websocket.ts
+++ b/web/src/lib/websocket.ts
@@ -1,9 +1,24 @@
-import { Client, type IMessage } from '@stomp/stompjs';
+import { Client, type IMessage, type StompSubscription } from '@stomp/stompjs';
 import { getAuthState } from '$lib/stores/auth.svelte';
 
 let client: Client | null = null;
+let connected = $state(false);
+let onConnectCallbacks: Array<() => void> = [];
+
+export function getConnected() {
+	return {
+		get value() { return connected; }
+	};
+}
 
 export function connect(onConnect?: () => void) {
+	if (onConnect) onConnectCallbacks.push(onConnect);
+	if (client?.connected) {
+		onConnect?.();
+		return;
+	}
+	if (client?.active) return;
+
 	const auth = getAuthState();
 	const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 	const wsUrl = `${protocol}//${window.location.host}/ws`;
@@ -17,7 +32,11 @@ export function connect(onConnect?: () => void) {
 		heartbeatIncoming: 10000,
 		heartbeatOutgoing: 10000,
 		onConnect: () => {
-			onConnect?.();
+			connected = true;
+			onConnectCallbacks.forEach((cb) => cb());
+		},
+		onDisconnect: () => {
+			connected = false;
 		},
 		onStompError: (frame) => {
 			console.error('STOMP error:', frame.headers['message']);
@@ -27,7 +46,7 @@ export function connect(onConnect?: () => void) {
 	client.activate();
 }
 
-export function subscribe(destination: string, callback: (msg: IMessage) => void) {
+export function subscribe(destination: string, callback: (msg: IMessage) => void): StompSubscription | null {
 	if (!client?.connected) return null;
 	return client.subscribe(destination, callback);
 }
@@ -41,6 +60,8 @@ export function disconnect() {
 	if (client) {
 		client.deactivate();
 		client = null;
+		connected = false;
+		onConnectCallbacks = [];
 	}
 }
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -4,6 +4,10 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { initAuth, getAuthState } from '$lib/stores/auth.svelte';
+	import { connect, subscribe, disconnect } from '$lib/websocket';
+	import { handleNotification, loadUnreadCounts, type NotificationPayload } from '$lib/stores/notifications.svelte';
+	import { initPushNotifications } from '$lib/push';
+	import Toast from '$lib/components/Toast.svelte';
 
 	let { children } = $props();
 
@@ -22,6 +26,20 @@
 
 	$effect(() => {
 		document.documentElement.classList.add('dark');
+	});
+
+	$effect(() => {
+		if (auth.isAuthenticated) {
+			connect(() => {
+				subscribe('/user/queue/notifications', (msg) => {
+					const payload: NotificationPayload = JSON.parse(msg.body);
+					handleNotification(payload);
+				});
+			});
+			loadUnreadCounts();
+			initPushNotifications();
+		}
+		return () => disconnect();
 	});
 </script>
 
@@ -43,4 +61,5 @@
 	<div class="min-h-screen bg-background text-foreground">
 		{@render children()}
 	</div>
+	<Toast />
 {/if}

--- a/web/src/routes/rooms/+page.svelte
+++ b/web/src/routes/rooms/+page.svelte
@@ -8,7 +8,9 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Alert from '$lib/components/ui/alert';
+	import { getNotificationState } from '$lib/stores/notifications.svelte';
 
+	const notifications = getNotificationState();
 	let rooms = $state<Room[]>([]);
 	let showCreate = $state(false);
 	let newName = $state('');
@@ -97,7 +99,12 @@
 									<h2 class="font-medium">
 										<span class="text-primary">#</span> {room.name}
 									</h2>
-									<Badge variant="secondary">{room.memberCount} 人</Badge>
+									<div class="flex items-center gap-2">
+										{#if notifications.unreadCounts[room.id]}
+											<Badge variant="destructive">{notifications.unreadCounts[room.id]}</Badge>
+										{/if}
+										<Badge variant="secondary">{room.memberCount} 人</Badge>
+									</div>
 								</div>
 								{#if room.description}
 									<p class="mt-1 text-sm text-muted-foreground">{room.description}</p>

--- a/web/src/routes/rooms/[roomId]/+page.svelte
+++ b/web/src/routes/rooms/[roomId]/+page.svelte
@@ -3,7 +3,8 @@
 	import { goto } from '$app/navigation';
 	import { getMessages, getRoom, getUploadUrl, getDownloadUrl, leaveRoom, searchMessages, type Message, type Room } from '$lib/api';
 	import { getAuthState } from '$lib/stores/auth.svelte';
-	import { connect, subscribe, send, disconnect, isConnected } from '$lib/websocket';
+	import { subscribe, send, getConnected } from '$lib/websocket';
+	import { setCurrentRoom, clearUnread } from '$lib/stores/notifications.svelte';
 	import { HugeiconsIcon } from '@hugeicons/svelte';
 	import { Attachment01Icon, Image01Icon, SentIcon } from '@hugeicons/core-free-icons';
 
@@ -20,6 +21,7 @@
 
 	const roomId = $derived(page.params.roomId);
 	const auth = getAuthState();
+	const ws = getConnected();
 
 	async function loadRoom() {
 		try {
@@ -37,14 +39,12 @@
 		setTimeout(() => messagesEnd?.scrollIntoView({ behavior: 'smooth' }), 50);
 	}
 
-	function connectWebSocket() {
-		connect(() => {
-			subscribe(`/topic/room.${roomId}`, (msg) => {
-				const message: Message = JSON.parse(msg.body);
-				messages = [...messages, message];
-				resolveImageUrl(message);
-				scrollToBottom();
-			});
+	function subscribeToRoom() {
+		return subscribe(`/topic/room.${roomId}`, (msg) => {
+			const message: Message = JSON.parse(msg.body);
+			messages = [...messages, message];
+			resolveImageUrl(message);
+			scrollToBottom();
 		});
 	}
 
@@ -114,9 +114,17 @@
 	$effect(() => {
 		if (auth.isAuthenticated && roomId) {
 			loadRoom();
-			connectWebSocket();
+			setCurrentRoom(roomId);
+			clearUnread(roomId);
 		}
-		return () => disconnect();
+		return () => setCurrentRoom(null);
+	});
+
+	$effect(() => {
+		if (ws.value && roomId) {
+			const sub = subscribeToRoom();
+			return () => sub?.unsubscribe();
+		}
 	});
 </script>
 

--- a/web/src/tests/setup.ts
+++ b/web/src/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -1,0 +1,40 @@
+self.addEventListener('push', (event) => {
+	const data = event.data?.json() ?? {};
+	const title = data.senderName ?? 'New message';
+	const options = {
+		body: data.contentPreview ?? '',
+		tag: `room-${data.roomId}`,
+		renotify: true,
+		data: { roomId: data.roomId }
+	};
+
+	event.waitUntil(
+		clients
+			.matchAll({ type: 'window', includeUncontrolled: true })
+			.then((windowClients) => {
+				const isRoomOpen = windowClients.some(
+					(c) => c.visibilityState === 'visible' && c.url.includes(`/rooms/${data.roomId}`)
+				);
+				if (isRoomOpen) return;
+				return self.registration.showNotification(title, options);
+			})
+	);
+});
+
+self.addEventListener('notificationclick', (event) => {
+	event.notification.close();
+	const roomId = event.notification.data?.roomId;
+	const url = roomId ? `/rooms/${roomId}` : '/rooms';
+
+	event.waitUntil(
+		clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+			for (const client of windowClients) {
+				if ('focus' in client) {
+					client.navigate(url);
+					return client.focus();
+				}
+			}
+			return clients.openWindow(url);
+		})
+	);
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,14 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [sveltekit()],
+	define: {
+		global: 'globalThis'
+	},
+	test: {
+		include: ['src/**/*.test.ts'],
+		environment: 'jsdom',
+		setupFiles: ['src/tests/setup.ts']
+	}
+});


### PR DESCRIPTION
## Summary
- **SQS通知パイプライン**: ChatService → SQS送信 → SqsMessageListener → 通知ディスパッチ（ローカル開発はSpring Event fallback）
- **アプリ内通知**: STOMP WebSocketでトースト通知 + Redis未読バッジ（NotificationService → `/user/queue/notifications`）
- **Web Push通知**: VAPID認証 + Service Worker + PushSubscription DB管理（WebPushService → ブラウザ通知）
- **テスト全面追加**: ユニット62件 + 結合24件(Testcontainers) + フロントエンド33件(Vitest) + E2E(Playwright)

## 新規ファイル (Backend)
- `SqsNotificationService` — SQS送信、未設定時はSpring Event発行
- `NotificationService` — ルームメンバーへSTOMP通知 + Redis未読カウント
- `WebPushService` — Web Push送信、410 Goneで購読自動削除
- `NotificationController` — 未読カウントAPI (`GET/DELETE /api/notifications/unread`)
- `PushSubscriptionController` — Push購読API (`GET /api/push/vapid-key`, `POST /api/push/subscribe`)
- `V6__create_push_subscriptions.sql` — DBマイグレーション

## 新規ファイル (Frontend)
- `notifications.svelte.ts` — 未読カウント + トースト状態管理
- `Toast.svelte` — 右下固定トースト通知（5秒自動消去）
- `push.ts` — Service Worker登録 + Web Push購読
- `sw.js` — Push受信 → ブラウザ通知、クリックでルーム遷移

## 変更ファイル
- `+layout.svelte` — WebSocket接続 + 通知購読をレイアウトに集約
- `rooms/[roomId]/+page.svelte` — connect/disconnect削除、トピック購読のみ + 未読クリア
- `rooms/+page.svelte` — ルームカードに未読バッジ表示

## テスト (119 tests)
| カテゴリ | テスト数 |
|---------|---------|
| Backend ユニット (Mockito) | 62 |
| Backend 結合 (Testcontainers PostgreSQL + Redis) | 24 |
| Frontend ユニット (Vitest) | 33 |
| Frontend E2E (Playwright) | 7 (要ブラウザ) |

## Test plan
- [x] `cd api && gradle test` — Backend 86テスト全通過
- [x] `cd web && pnpm test` — Frontend 33テスト全通過
- [ ] ローカル起動 → メッセージ送信 → 別ルームでトースト表示確認
- [ ] ルーム一覧に未読バッジ表示確認
- [ ] ブラウザ通知許可 → タブ閉じた状態でメッセージ受信 → OS通知表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)