### PR TITLE
feat: ArgoCD Image Updater導入 + CDパイプライン簡素化

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -13,9 +13,6 @@ env:
   AWS_REGION: ap-northeast-1
   ECR_REPOSITORY: chat-api
 
-permissions:
-  contents: write
-
 jobs:
   deploy-infra:
     runs-on: ubuntu-latest
@@ -56,24 +53,8 @@ jobs:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
         run: |
           cd api
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: flox/install-flox-action@main
-
-      - name: Update manifest image tag
-        env:
-          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
-        run: flox activate -- bash -c 'cd manifests/base && kustomize edit set image chat-api=$ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA'
-
-      - name: Commit and push manifest update
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add manifests/base/kustomization.yaml
-          git commit -m "deploy: update chat-api image to $GITHUB_SHA"
-          git push
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:prod .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:prod
 
   deploy-web:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "api/**"
-      - "web/**"
   merge_group:
     branches: [main]
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | 通知 | Web Push (VAPID) + アプリ内トースト + 未読バッジ |
 | テスト | JUnit 5 + Mockito + Testcontainers / Vitest / Playwright |
 | IaC | Terraform (S3バックエンド + DynamoDB state lock) |
-| CI/CD | GitHub Actions + flox (Terraform apply + Docker build 自動化) |
+| CI/CD | GitHub Actions + ArgoCD Image Updater |
 | 配信 | CloudFront (S3 + ALB を同一ドメインで配信) |
 
 ## 使ってるAWSサービス
@@ -111,13 +111,23 @@ Vite のプロキシで `/api/*` と `/ws` が Spring Boot に流れる。
 
 ## デプロイ
 
-```bash
-cd ~/dev/chat/infra && terraform apply
+main に push すると自動デプロイ。
+
+```
+main push → GitHub Actions
+  ├── deploy-api: Docker build → ECR push (:prod タグ上書き)
+  ├── deploy-web: pnpm build → S3 sync → CloudFront invalidate
+  └── deploy-infra: terraform apply (infra/ 変更時のみ)
+
+ECR push 後:
+  ArgoCD Image Updater が prod タグの digest 変更を検知 → ArgoCD sync → Pod 更新
 ```
 
-使い終わったら壊す。
+マニフェストへの git push は不要。Image Updater がクラスタ内から ECR を監視して自動反映。
 
 ```bash
+# インフラを手動で立てる/壊す場合
+cd ~/dev/chat/infra && terraform apply
 cd ~/dev/chat/infra && terraform destroy
 ```
 

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -25,6 +25,7 @@ graph TB
                 subgraph EKS Cluster
                     API[Spring Boot<br/>chat-api Pod]
                     ES[Elasticsearch<br/>Pod]
+                    ImageUpdater[ArgoCD<br/>Image Updater]
                 end
                 RDS[(RDS<br/>PostgreSQL)]
                 Redis[(ElastiCache<br/>Redis)]
@@ -44,6 +45,8 @@ graph TB
     API -->|Presigned URL| S3Upload
     API --> ES
     ECR -.->|Image Pull| API
+    ImageUpdater -->|Digest監視| ECR
+    ImageUpdater -->|Sync| API
     API -.->|IRSA| SQS
     API -.->|IRSA| S3Upload
 
@@ -58,4 +61,4 @@ graph TB
     class S3Front,S3Upload,ECR storage
     class RDS,Redis,ES database
     class Cognito security
-    class API network
+    class API,ImageUpdater network

--- a/infra/irsa.tf
+++ b/infra/irsa.tf
@@ -28,6 +28,56 @@ module "irsa_chat_api" {
   }
 }
 
+module "irsa_image_updater" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
+
+  role_name = "argocd-image-updater"
+
+  oidc_providers = {
+    main = {
+      provider_arn               = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_provider_arn}"
+      namespace_service_accounts = ["argocd:argocd-image-updater"]
+    }
+  }
+
+  role_policy_arns = {
+    ecr_read = aws_iam_policy.image_updater_ecr.arn
+  }
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_iam_policy" "image_updater_ecr" {
+  name        = "argocd-image-updater-ecr"
+  description = "Allow Image Updater to read ECR"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:DescribeImages",
+          "ecr:ListImages",
+        ]
+        Resource = aws_ecr_repository.chat_api.arn
+      },
+    ]
+  })
+}
+
 resource "aws_iam_policy" "chat_api_access" {
   name        = "${var.project}-api-access"
   description = "Policy for chat API to access S3 and SQS"

--- a/manifests/argocd/application.yaml
+++ b/manifests/argocd/application.yaml
@@ -3,6 +3,10 @@ kind: Application
 metadata:
   name: chat
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: chat-api=831963379503.dkr.ecr.ap-northeast-1.amazonaws.com/chat-api
+    argocd-image-updater.argoproj.io/chat-api.update-strategy: digest
+    argocd-image-updater.argoproj.io/chat-api.allow-tags: "regexp:^prod$"
 spec:
   project: default
   source:

--- a/manifests/argocd/image-updater.yaml
+++ b/manifests/argocd/image-updater.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-image-updater
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://argoproj.github.io/argo-helm
+    chart: argocd-image-updater
+    targetRevision: 0.11.0
+    helm:
+      values: |
+        config:
+          registries:
+            - name: ECR
+              api_url: https://831963379503.dkr.ecr.ap-northeast-1.amazonaws.com
+              prefix: 831963379503.dkr.ecr.ap-northeast-1.amazonaws.com
+              credentials: ext:/scripts/ecr-login.sh
+              credsexpire: 10h
+        authScripts:
+          enabled: true
+          scripts:
+            ecr-login.sh: |
+              #!/bin/sh
+              aws ecr get-login-password --region ap-northeast-1
+        serviceAccount:
+          annotations:
+            eks.amazonaws.com/role-arn: arn:aws:iam::831963379503:role/argocd-image-updater
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -13,4 +13,4 @@ resources:
 images:
 - name: chat-api
   newName: 831963379503.dkr.ecr.ap-northeast-1.amazonaws.com/chat-api
-  newTag: 35f585e9587f81d5f9147eb2878f572167b93bfd
+  newTag: prod


### PR DESCRIPTION
## Summary
- ECRタグをSHA → `prod` 固定に変更（タグ上書き方式）
- CDから git push ステップを削除（bypass rule 不要に）
- ArgoCD Image Updater を Helm 経由でインストール（digest 戦略で `prod` タグ監視）
- Image Updater 用 IRSA 追加（ECR read 権限）

## デプロイフロー（Before → After）

**Before:**
CD: Docker build → ECR push (:SHA) → kustomize edit → git push main ← branch protection で失敗

**After:**
CD: Docker build → ECR push (:prod) → 終わり
Image Updater: prod タグの digest 変更を検知 → ArgoCD sync

## 変更ファイル
| ファイル | 変更 |
|---------|------|
| cd.yaml | タグを prod に変更、git push ステップ削除 |
| kustomization.yaml | newTag: SHA → newTag: prod |
| application.yaml | Image Updater アノテーション追加 |
| image-updater.yaml | 新規 — Helm で Image Updater インストール |
| irsa.tf | Image Updater 用 IRSA + ECR read ポリシー追加 |

## Test plan
- [ ] terraform plan で IRSA リソース確認
- [ ] Image Updater Pod が argocd namespace で起動することを確認
- [ ] ECR に prod タグ push 後、ArgoCD が自動で sync することを確認