### PR TITLE
feat: OpenAPI (Swagger UI) 追加

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,55 @@
+name: Deploy Swagger UI to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "api/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: flox/install-flox-action@main
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('api/build.gradle.kts', 'api/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Generate OpenAPI spec
+        run: flox activate -- bash -c 'cd api && gradle test --tests "com.example.chat.integration.OpenApiSpecTest"'
+
+      - name: Prepare Pages content
+        run: |
+          mkdir -p _site
+          cp docs/swagger/index.html _site/
+          cp api/build/openapi/openapi.json _site/
+
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     implementation("software.amazon.awssdk:s3")
     implementation("software.amazon.awssdk:sts")
 
+    // OpenAPI
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+
     // Web Push
     implementation("nl.martijndwars:web-push:5.1.1")
     implementation("org.bouncycastle:bcprov-jdk18on:1.80")

--- a/api/src/main/java/com/example/chat/config/LocalSecurityConfig.java
+++ b/api/src/main/java/com/example/chat/config/LocalSecurityConfig.java
@@ -38,6 +38,7 @@ public class LocalSecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated()

--- a/api/src/main/java/com/example/chat/config/SecurityConfig.java
+++ b/api/src/main/java/com/example/chat/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated()

--- a/api/src/test/java/com/example/chat/integration/OpenApiSpecTest.java
+++ b/api/src/test/java/com/example/chat/integration/OpenApiSpecTest.java
@@ -1,0 +1,29 @@
+package com.example.chat.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OpenApiSpecTest extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void exportOpenApiSpec() throws Exception {
+        var result = mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String json = result.getResponse().getContentAsString();
+        Path outputDir = Path.of("build", "openapi");
+        Files.createDirectories(outputDir);
+        Files.writeString(outputDir.resolve("openapi.json"), json);
+    }
+}

--- a/docs/swagger/index.html
+++ b/docs/swagger/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>Chat API - Swagger UI</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css">
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+        SwaggerUIBundle({
+            url: './openapi.json',
+            dom_id: '#swagger-ui',
+            presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
+            layout: 'BaseLayout'
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `springdoc-openapi-starter-webmvc-ui` 追加（依存1行のみ）
- `/swagger-ui/index.html` でAPI仕様を確認可能
- SecurityConfig で Swagger UI パスを permitAll に設定

## 確認方法
ローカル起動後: http://localhost:8080/swagger-ui/index.html

## Test plan
- [x] `gradle compileJava` 成功
- [x] ユニットテスト全通過
- [ ] ローカル起動 → `/swagger-ui/index.html` でUI表示確認