### PR TITLE
fix: DMルーム作成時に相手を自動参加させる

### DIFF
--- a/api/src/main/java/com/example/chat/controller/RoomController.java
+++ b/api/src/main/java/com/example/chat/controller/RoomController.java
@@ -35,7 +35,8 @@ public class RoomController {
                 request.name(),
                 request.description(),
                 principal.getName(),
-                principal.getName()
+                principal.getName(),
+                request.memberIds()
         );
     }
 

--- a/api/src/main/java/com/example/chat/model/dto/RoomRequest.java
+++ b/api/src/main/java/com/example/chat/model/dto/RoomRequest.java
@@ -1,4 +1,6 @@
 package com.example.chat.model.dto;
 
-public record RoomRequest(String name, String description) {
+import java.util.List;
+
+public record RoomRequest(String name, String description, List<String> memberIds) {
 }

--- a/api/src/main/java/com/example/chat/service/RoomService.java
+++ b/api/src/main/java/com/example/chat/service/RoomService.java
@@ -5,6 +5,7 @@ import com.example.chat.model.entity.ChatRoom;
 import com.example.chat.model.entity.RoomMember;
 import com.example.chat.repository.ChatRoomRepository;
 import com.example.chat.repository.RoomMemberRepository;
+import com.example.chat.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -18,35 +19,57 @@ public class RoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final RoomMemberRepository roomMemberRepository;
+    private final UserRepository userRepository;
     private final ChatService chatService;
     private final SimpMessagingTemplate messagingTemplate;
 
     public RoomService(ChatRoomRepository chatRoomRepository,
                        RoomMemberRepository roomMemberRepository,
+                       UserRepository userRepository,
                        ChatService chatService,
                        SimpMessagingTemplate messagingTemplate) {
         this.chatRoomRepository = chatRoomRepository;
         this.roomMemberRepository = roomMemberRepository;
+        this.userRepository = userRepository;
         this.chatService = chatService;
         this.messagingTemplate = messagingTemplate;
     }
 
     @Transactional
-    public RoomResponse createRoom(String name, String description, String userId, String userName) {
+    public RoomResponse createRoom(String name, String description, String userId, String userName,
+                                   List<String> memberIds) {
         var room = new ChatRoom();
         room.setName(name);
         room.setDescription(description);
         room.setCreatedBy(userId);
         chatRoomRepository.save(room);
 
-        var member = new RoomMember();
-        member.setRoomId(room.getId());
-        member.setUserId(userId);
-        member.setUserName(userName);
-        member.setRole("OWNER");
-        roomMemberRepository.save(member);
+        var owner = new RoomMember();
+        owner.setRoomId(room.getId());
+        owner.setUserId(userId);
+        owner.setUserName(userName);
+        owner.setRole("OWNER");
+        roomMemberRepository.save(owner);
 
-        return toResponse(room, 1);
+        int memberCount = 1;
+        if (memberIds != null) {
+            for (String memberId : memberIds) {
+                if (memberId.equals(userId)) continue;
+                var userOpt = userRepository.findById(memberId);
+                if (userOpt.isPresent()) {
+                    var user = userOpt.get();
+                    var member = new RoomMember();
+                    member.setRoomId(room.getId());
+                    member.setUserId(user.getId());
+                    member.setUserName(user.getDisplayName());
+                    member.setRole("MEMBER");
+                    roomMemberRepository.save(member);
+                    memberCount++;
+                }
+            }
+        }
+
+        return toResponse(room, memberCount);
     }
 
     @Transactional(readOnly = true)

--- a/api/src/test/java/com/example/chat/service/RoomServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/RoomServiceTest.java
@@ -4,8 +4,10 @@ import com.example.chat.model.dto.RoomResponse;
 import com.example.chat.model.entity.ChatMessage;
 import com.example.chat.model.entity.ChatRoom;
 import com.example.chat.model.entity.RoomMember;
+import com.example.chat.model.entity.User;
 import com.example.chat.repository.ChatRoomRepository;
 import com.example.chat.repository.RoomMemberRepository;
+import com.example.chat.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +38,9 @@ class RoomServiceTest {
     private RoomMemberRepository roomMemberRepository;
 
     @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private ChatService chatService;
 
     @Mock
@@ -57,7 +62,7 @@ class RoomServiceTest {
         });
         when(roomMemberRepository.save(any(RoomMember.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        RoomResponse response = roomService.createRoom("general", "General chat", "user1", "Alice");
+        RoomResponse response = roomService.createRoom("general", "General chat", "user1", "Alice", null);
 
         assertThat(response.id()).isEqualTo(roomId);
         assertThat(response.name()).isEqualTo("general");
@@ -72,6 +77,49 @@ class RoomServiceTest {
         assertThat(savedMember.getUserId()).isEqualTo("user1");
         assertThat(savedMember.getUserName()).isEqualTo("Alice");
         assertThat(savedMember.getRole()).isEqualTo("OWNER");
+    }
+
+    @Test
+    void createRoom_withMemberIds_addsMembers() {
+        var roomId = UUID.randomUUID();
+        var now = Instant.now();
+
+        when(chatRoomRepository.save(any(ChatRoom.class))).thenAnswer(invocation -> {
+            ChatRoom room = invocation.getArgument(0);
+            room.setId(roomId);
+            room.setCreatedAt(now);
+            return room;
+        });
+        when(roomMemberRepository.save(any(RoomMember.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var friend = new User();
+        friend.setId("user2");
+        friend.setDisplayName("Bob");
+        when(userRepository.findById("user2")).thenReturn(Optional.of(friend));
+
+        RoomResponse response = roomService.createRoom("Bob", "DM", "user1", "Alice", List.of("user2"));
+
+        assertThat(response.memberCount()).isEqualTo(2);
+        verify(roomMemberRepository, times(2)).save(any(RoomMember.class));
+    }
+
+    @Test
+    void createRoom_withMemberIds_skipsCreatorId() {
+        var roomId = UUID.randomUUID();
+
+        when(chatRoomRepository.save(any(ChatRoom.class))).thenAnswer(invocation -> {
+            ChatRoom room = invocation.getArgument(0);
+            room.setId(roomId);
+            room.setCreatedAt(Instant.now());
+            return room;
+        });
+        when(roomMemberRepository.save(any(RoomMember.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RoomResponse response = roomService.createRoom("Self", "DM", "user1", "Alice", List.of("user1"));
+
+        assertThat(response.memberCount()).isEqualTo(1);
+        verify(roomMemberRepository, times(1)).save(any(RoomMember.class));
+        verify(userRepository, never()).findById(any());
     }
 
     @Test

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -43,8 +43,8 @@ export interface PageResponse<T> {
 	number: number;
 }
 
-export const createRoom = (name: string, description: string) =>
-	request<Room>('POST', '/api/rooms', { name, description });
+export const createRoom = (name: string, description: string, memberIds?: string[]) =>
+	request<Room>('POST', '/api/rooms', { name, description, memberIds });
 
 export const listRooms = () =>
 	request<Room[]>('GET', '/api/rooms');

--- a/web/src/routes/friends/+page.svelte
+++ b/web/src/routes/friends/+page.svelte
@@ -60,7 +60,7 @@
 	}
 
 	async function handleStartChat(friend: UserInfo) {
-		const room = await createRoom(`${friend.displayName}`, 'DM');
+		const room = await createRoom(`${friend.displayName}`, 'DM', [friend.id]);
 		goto(`/rooms/${room.id}`);
 	}
 


### PR DESCRIPTION
## Summary
フレンドページの「Chat」ボタンでDMルームを作成した際、相手がルームに参加しておらず、メッセージが届かない問題を修正。

- `RoomRequest` に `memberIds` フィールド追加（オプション、既存の新規作成ダイアログには影響なし）
- `RoomService.createRoom` で `memberIds` のユーザーを MEMBER として自動参加
- フロントの `handleStartChat` で相手の ID を `createRoom` に渡す

## Test plan
- [x] `RoomServiceTest` — memberIds 付きルーム作成、自分のID重複スキップ
- [x] `gradle compileJava` 成功
- [x] `pnpm build` 成功
- [ ] フレンドの「Chat」→ ルーム作成 → 相手のルーム一覧に表示されることを確認