### PR TITLE
fix: RDS/Redis SGのEKSノードSGフィルタ修正

### DIFF
--- a/infra/data.tf
+++ b/infra/data.tf
@@ -45,8 +45,8 @@ data "aws_lb" "chat" {
 
 data "aws_security_groups" "eks_nodes" {
   filter {
-    name   = "tag:aws:eks:cluster-name"
-    values = [var.eks_cluster_name]
+    name   = "tag:kubernetes.io/cluster/${var.eks_cluster_name}"
+    values = ["owned"]
   }
 
   filter {


### PR DESCRIPTION
## Summary
PodからRDS/Redisに接続できずchat-apiがCrashLoopBackOffになっていた問題の根本修正。

### 原因
`data.aws_security_groups.eks_nodes` が `aws:eks:cluster-name` タグでフィルタしていたが、EKSノードのSGにはこのタグがない（クラスタSGにだけ存在）。結果、RDS/RedisのSGにノードSGが含まれず接続がタイムアウト。

### 修正
フィルタを `kubernetes.io/cluster/{name} = owned` に変更。このタグはクラスタSG・ノードSG 両方に付いているため、両方のSGが取得される。

## Test plan
- [ ] `terraform plan` で RDS/Redis SG の ingress にノード SG が追加されることを確認
- [ ] `terraform apply` 後、Pod が正常起動して DB/Redis に接続できることを確認