### PR TITLE
ci: Nix/flox削除 → 標準Actions化でCI高速化

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -67,14 +67,21 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: flox/install-flox-action@main
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Build web
         env:
           VITE_COGNITO_USER_POOL_ID: ap-northeast-1_qPedGpbby
           VITE_COGNITO_CLIENT_ID: 7vsovq6esg1am78jmk3diucc3q
-        run: flox activate -- bash -c 'cd web && pnpm install --frozen-lockfile && pnpm build'
+        run: cd web && pnpm install --frozen-lockfile && pnpm build
 
       - name: Deploy to S3
         run: aws s3 sync web/build/ s3://${{ secrets.FRONTEND_BUCKET }} --delete

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,53 +11,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: flox/install-flox-action@main
 
-      - name: Cache Gradle
-        uses: actions/cache@v4
+      - uses: actions/setup-java@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ hashFiles('api/build.gradle.kts', 'api/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: gradle-
+          distribution: temurin
+          java-version: 21
 
-      - name: Cache Docker images
-        uses: actions/cache@v4
-        with:
-          path: /tmp/docker-cache
-          key: docker-${{ runner.os }}-testcontainers
-          restore-keys: docker-${{ runner.os }}-
-
-      - name: Load cached Docker images
-        run: |
-          if [ -f /tmp/docker-cache/postgres.tar ]; then docker load -i /tmp/docker-cache/postgres.tar; fi
-          if [ -f /tmp/docker-cache/redis.tar ]; then docker load -i /tmp/docker-cache/redis.tar; fi
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Run API tests
-        run: flox activate -- bash -c 'cd api && gradle test'
-
-      - name: Save Docker images to cache
-        if: always()
-        run: |
-          mkdir -p /tmp/docker-cache
-          docker save postgres:16-alpine -o /tmp/docker-cache/postgres.tar 2>/dev/null || true
-          docker save redis:7-alpine -o /tmp/docker-cache/redis.tar 2>/dev/null || true
+        run: cd api && ./gradlew test
 
   build-web:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: flox/install-flox-action@main
 
-      - name: Cache pnpm store
-        uses: actions/cache@v4
+      - uses: pnpm/action-setup@v4
         with:
-          path: ~/.local/share/pnpm/store
-          key: pnpm-${{ hashFiles('web/pnpm-lock.yaml') }}
-          restore-keys: pnpm-
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Build web
-        run: flox activate -- bash -c 'cd web && pnpm install --frozen-lockfile && pnpm build'
+        run: cd web && pnpm install --frozen-lockfile && pnpm build

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -21,20 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: flox/install-flox-action@main
 
-      - name: Cache Gradle
-        uses: actions/cache@v4
+      - uses: actions/setup-java@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ hashFiles('api/build.gradle.kts', 'api/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: gradle-
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Generate OpenAPI spec
-        run: flox activate -- bash -c 'cd api && gradle test --tests "com.example.chat.integration.OpenApiSpecTest"'
+        run: cd api && ./gradlew test --tests "com.example.chat.integration.OpenApiSpecTest"
 
       - name: Prepare Pages content
         run: |


### PR DESCRIPTION
## Summary
CI/CD/Pages の全ワークフローから Nix/flox を削除し、標準の GitHub Actions に置き換え。

## Before → After
| ステップ | Before | After |
|---------|--------|-------|
| Java | flox activate (Nix) | setup-java (temurin 21) |
| Gradle | flox内のgradle | gradle/actions/setup-gradle（キャッシュ自動） |
| Node/pnpm | flox activate (Nix) | pnpm/action-setup + setup-node（キャッシュ自動） |
| Nix install | ~8秒 | なし |
| flox install | ~30秒 | なし |
| **予想所要時間** | **~8分** | **~3-4分** |

## Test plan
- [ ] CI（test-api + build-web）が通ることを確認
- [ ] CD（deploy-api + deploy-web）が通ることを確認