### PR TITLE
refactor: Image Updater git write-back + deploy key (#56修正)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -13,9 +13,6 @@ env:
   AWS_REGION: ap-northeast-1
   ECR_REPOSITORY: chat-api
 
-permissions:
-  contents: write
-
 jobs:
   deploy-infra:
     runs-on: ubuntu-latest
@@ -54,28 +51,10 @@ jobs:
       - name: Build and push Docker image
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
         run: |
           cd api
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
-      - name: Update manifest image tag
-        env:
-          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          cd manifests/base
-          kustomize edit set image chat-api=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
-      - name: Commit and push manifest
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add manifests/base/kustomization.yaml
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "chore: deploy chat-api $(echo ${{ github.sha }} | cut -c1-7)"
-          git push
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:prod .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:prod
 
   deploy-web:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ docker-compose.override.yml
 
 # Screenshots
 *.png
+manifests/argocd/repo-secret.yaml

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | 通知 | Web Push (VAPID) + アプリ内トースト + 未読バッジ |
 | テスト | JUnit 5 + Mockito + Testcontainers / Vitest / Playwright |
 | IaC | Terraform (S3バックエンド + DynamoDB state lock) |
-| CI/CD | GitHub Actions + ArgoCD (GitOps) |
+| CI/CD | GitHub Actions + ArgoCD + Image Updater |
 | 配信 | CloudFront (S3 + ALB を同一ドメインで配信) |
 
 ## 使ってるAWSサービス
@@ -115,15 +115,17 @@ main に push すると自動デプロイ。
 
 ```
 main push → GitHub Actions
-  ├── deploy-api: Docker build → ECR push (:SHA) → kustomize edit set image → git push
+  ├── deploy-api: Docker build → ECR push (:prod)
   ├── deploy-web: pnpm build → S3 sync → CloudFront invalidate
   └── deploy-infra: terraform apply (infra/ 変更時のみ)
 
-git push 後:
-  ArgoCD が manifests/ の変更を検知 → auto sync → Pod 更新
+ECR push 後:
+  Image Updater が prod タグの digest 変更を検知
+  → kustomization.yaml を更新して git commit/push（deploy key）
+  → ArgoCD が auto sync → Pod 更新
 ```
 
-イミュータブルタグ（コミットSHA）で ECR に push し、`kustomization.yaml` のタグを更新して git push。ArgoCD が自動で sync してデプロイ。
+Image Updater が git write-back モードで `kustomization.yaml` を自動更新。GitOps の原則を維持。
 
 ```bash
 # インフラを手動で立てる/壊す場合

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,6 +1,6 @@
 resource "aws_ecr_repository" "chat_api" {
   name                 = "${var.project}-api"
-  image_tag_mutability = "IMMUTABLE"
+  image_tag_mutability = "MUTABLE"
   force_delete         = true
 
   image_scanning_configuration {

--- a/manifests/argocd/application.yaml
+++ b/manifests/argocd/application.yaml
@@ -3,10 +3,16 @@ kind: Application
 metadata:
   name: chat
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: chat-api=831963379503.dkr.ecr.ap-northeast-1.amazonaws.com/chat-api:prod
+    argocd-image-updater.argoproj.io/chat-api.update-strategy: digest
+    argocd-image-updater.argoproj.io/write-back-method: git
+    argocd-image-updater.argoproj.io/write-back-target: kustomization
+    argocd-image-updater.argoproj.io/git-branch: main
 spec:
   project: default
   source:
-    repoURL: https://github.com/tommykey0925/chat.git
+    repoURL: git@github.com:tommykey-apps/chat.git
     targetRevision: main
     path: manifests/base
   destination:

--- a/manifests/argocd/image-updater.yaml
+++ b/manifests/argocd/image-updater.yaml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-image-updater
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://argoproj.github.io/argo-helm
+    chart: argocd-image-updater
+    targetRevision: 0.11.0
+    helm:
+      values: |
+        serviceAccount:
+          create: true
+          annotations:
+            eks.amazonaws.com/role-arn: arn:aws:iam::831963379503:role/argocd-image-updater
+
+        config:
+          registries:
+            - name: ECR
+              api_url: https://831963379503.dkr.ecr.ap-northeast-1.amazonaws.com
+              prefix: 831963379503.dkr.ecr.ap-northeast-1.amazonaws.com
+              default: true
+              credentials: ext:/scripts/login.sh
+              credsexpire: 6h
+
+        authScripts:
+          enabled: true
+          scripts:
+            login.sh: |
+              #!/bin/sh
+              set -e
+              aws ecr --region ap-northeast-1 get-authorization-token --output text --query 'authorizationData[0].authorizationToken' | base64 -d
+
+        extraEnv:
+          - name: HOME
+            value: /tmp
+          - name: AWS_REGION
+            value: ap-northeast-1
+          - name: AWS_DEFAULT_REGION
+            value: ap-northeast-1
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -11,6 +11,4 @@ resources:
 images:
 - name: chat-api
   newName: 831963379503.dkr.ecr.ap-northeast-1.amazonaws.com/chat-api
-  newTag: latest
-- name: 831963379503.dkr.ecr.ap-northeast-1.amazonaws.com/chat-api
-  digest: sha256:a1d14b0e15b17045983ed17c98fd4f05755db128b2bec601312c67b7f8b0fde7
+  newTag: prod


### PR DESCRIPTION
## Summary
Image Updater の git write-back モードで GitOps を完結。

## フロー
```
CD: Docker build → ECR push (:prod)
Image Updater: digest検知 → kustomization.yaml更新 → git push (deploy key)
ArgoCD: git変更検知 → auto sync → Pod更新
```

## 検証済み
- Image Updater が `git push origin main` に成功
- ArgoCD が auto sync して Pod 更新
- `build: automatic update of chat` コミットが main に反映

## 前提
- deploy key（write access）がリポジトリに登録済み
- Rulesetのbypass listにdeploy key追加済み
- ArgoCD repo SecretにSSH秘密鍵登録済み