### PR TITLE
feat: SQS正当化 + SESメール通知追加

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
 
     // AWS
     implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-ses")
     implementation("software.amazon.awssdk:s3")
     implementation("software.amazon.awssdk:sts")
 

--- a/api/src/main/java/com/example/chat/listener/LocalNotificationListener.java
+++ b/api/src/main/java/com/example/chat/listener/LocalNotificationListener.java
@@ -1,6 +1,7 @@
 package com.example.chat.listener;
 
 import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.service.EmailNotificationService;
 import com.example.chat.service.NotificationService;
 import com.example.chat.service.WebPushService;
 import org.slf4j.Logger;
@@ -17,10 +18,14 @@ public class LocalNotificationListener {
 
     private final NotificationService notificationService;
     private final WebPushService webPushService;
+    private final EmailNotificationService emailNotificationService;
 
-    public LocalNotificationListener(NotificationService notificationService, WebPushService webPushService) {
+    public LocalNotificationListener(NotificationService notificationService,
+                                      WebPushService webPushService,
+                                      EmailNotificationService emailNotificationService) {
         this.notificationService = notificationService;
         this.webPushService = webPushService;
+        this.emailNotificationService = emailNotificationService;
     }
 
     @EventListener
@@ -28,5 +33,6 @@ public class LocalNotificationListener {
         log.info("Local notification event: messageId={}, roomId={}", event.messageId(), event.roomId());
         notificationService.notifyRoomMembers(event);
         webPushService.sendPushToMembers(event);
+        emailNotificationService.sendEmailIfNeeded(event);
     }
 }

--- a/api/src/main/java/com/example/chat/listener/SqsMessageListener.java
+++ b/api/src/main/java/com/example/chat/listener/SqsMessageListener.java
@@ -1,6 +1,7 @@
 package com.example.chat.listener;
 
 import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.service.EmailNotificationService;
 import com.example.chat.service.NotificationService;
 import com.example.chat.service.WebPushService;
 import io.awspring.cloud.sqs.annotation.SqsListener;
@@ -15,10 +16,14 @@ public class SqsMessageListener {
 
     private final NotificationService notificationService;
     private final WebPushService webPushService;
+    private final EmailNotificationService emailNotificationService;
 
-    public SqsMessageListener(NotificationService notificationService, WebPushService webPushService) {
+    public SqsMessageListener(NotificationService notificationService,
+                               WebPushService webPushService,
+                               EmailNotificationService emailNotificationService) {
         this.notificationService = notificationService;
         this.webPushService = webPushService;
+        this.emailNotificationService = emailNotificationService;
     }
 
     @SqsListener("${app.sqs.chat-message-queue}")
@@ -27,5 +32,6 @@ public class SqsMessageListener {
                 event.messageId(), event.roomId(), event.senderId());
         notificationService.notifyRoomMembers(event);
         webPushService.sendPushToMembers(event);
+        emailNotificationService.sendEmailIfNeeded(event);
     }
 }

--- a/api/src/main/java/com/example/chat/service/ChatService.java
+++ b/api/src/main/java/com/example/chat/service/ChatService.java
@@ -15,13 +15,13 @@ public class ChatService {
 
     private final ChatMessageRepository chatMessageRepository;
     private final SearchService searchService;
-    private final SqsNotificationService sqsNotificationService;
+    private final NotificationSender notificationSender;
 
     public ChatService(ChatMessageRepository chatMessageRepository, SearchService searchService,
-                       SqsNotificationService sqsNotificationService) {
+                       NotificationSender notificationSender) {
         this.chatMessageRepository = chatMessageRepository;
         this.searchService = searchService;
-        this.sqsNotificationService = sqsNotificationService;
+        this.notificationSender = notificationSender;
     }
 
     @Transactional
@@ -40,7 +40,7 @@ public class ChatService {
             // ES障害時もメッセージ送信は成功させる
         }
         try {
-            sqsNotificationService.sendNotification(saved);
+            notificationSender.sendNotification(saved);
         } catch (Exception e) {
             // SQS障害時もメッセージ送信は成功させる
         }

--- a/api/src/main/java/com/example/chat/service/EmailNotificationService.java
+++ b/api/src/main/java/com/example/chat/service/EmailNotificationService.java
@@ -1,0 +1,95 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.repository.RoomMemberRepository;
+import com.example.chat.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+public class EmailNotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(EmailNotificationService.class);
+    private static final int UNREAD_THRESHOLD = 5;
+    private static final Duration EMAIL_COOLDOWN = Duration.ofHours(1);
+
+    private final MailSender mailSender;
+    private final RoomMemberRepository roomMemberRepository;
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final String fromAddress;
+
+    public EmailNotificationService(
+            ObjectProvider<MailSender> mailSenderProvider,
+            RoomMemberRepository roomMemberRepository,
+            UserRepository userRepository,
+            RedisTemplate<String, String> redisTemplate,
+            @Value("${app.ses.from-address:}") String fromAddress) {
+        this.mailSender = mailSenderProvider.getIfAvailable();
+        this.roomMemberRepository = roomMemberRepository;
+        this.userRepository = userRepository;
+        this.redisTemplate = redisTemplate;
+        this.fromAddress = fromAddress;
+    }
+
+    public void sendEmailIfNeeded(ChatNotificationEvent event) {
+        if (mailSender == null || fromAddress.isBlank()) {
+            log.debug("SES is not configured, skipping email notification");
+            return;
+        }
+
+        var members = roomMemberRepository.findByRoomId(event.roomId());
+        for (var member : members) {
+            if (member.getUserId().equals(event.senderId())) continue;
+
+            var unreadCount = getUnreadCount(member.getUserId(), event.roomId().toString());
+            if (unreadCount < UNREAD_THRESHOLD) continue;
+
+            var cooldownKey = "email-cooldown:" + member.getUserId();
+            if (Boolean.TRUE.equals(redisTemplate.hasKey(cooldownKey))) continue;
+
+            userRepository.findById(member.getUserId()).ifPresent(user -> {
+                sendUnreadNotificationEmail(user.getEmail(), user.getDisplayName(),
+                        event.senderName(), unreadCount);
+                redisTemplate.opsForValue().set(cooldownKey, "1", EMAIL_COOLDOWN);
+            });
+        }
+    }
+
+    private long getUnreadCount(String userId, String roomId) {
+        var count = redisTemplate.opsForHash().get("unread:" + userId, roomId);
+        if (count == null) return 0;
+        try {
+            return Long.parseLong(count.toString());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private void sendUnreadNotificationEmail(String to, String displayName,
+                                              String senderName, long unreadCount) {
+        try {
+            var message = new SimpleMailMessage();
+            message.setFrom(fromAddress);
+            message.setTo(to);
+            message.setSubject("chatto: " + unreadCount + "件の未読メッセージがあります");
+            message.setText(
+                    displayName + " さん\n\n" +
+                    senderName + " さんからのメッセージを含む " + unreadCount + " 件の未読メッセージがあります。\n\n" +
+                    "chattoを開いて確認しましょう:\nhttps://chat.tommykeyapp.com/rooms\n"
+            );
+            mailSender.send(message);
+            log.info("Sent unread notification email to {}", to);
+        } catch (Exception e) {
+            log.warn("Failed to send email to {}: {}", to, e.getMessage());
+        }
+    }
+}

--- a/api/src/main/java/com/example/chat/service/LocalNotificationSender.java
+++ b/api/src/main/java/com/example/chat/service/LocalNotificationSender.java
@@ -1,0 +1,38 @@
+package com.example.chat.service;
+
+import com.example.chat.model.dto.ChatNotificationEvent;
+import com.example.chat.model.entity.ChatMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("local")
+public class LocalNotificationSender implements NotificationSender {
+
+    private static final Logger log = LoggerFactory.getLogger(LocalNotificationSender.class);
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public LocalNotificationSender(ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override
+    public void sendNotification(ChatMessage message) {
+        var event = new ChatNotificationEvent(
+                message.getId(),
+                message.getRoomId(),
+                message.getSenderId(),
+                message.getSenderName(),
+                message.getContent(),
+                message.getMessageType(),
+                message.getCreatedAt()
+        );
+
+        eventPublisher.publishEvent(event);
+        log.debug("Published local notification event for message {}", message.getId());
+    }
+}

--- a/api/src/main/java/com/example/chat/service/NotificationSender.java
+++ b/api/src/main/java/com/example/chat/service/NotificationSender.java
@@ -1,0 +1,7 @@
+package com.example.chat.service;
+
+import com.example.chat.model.entity.ChatMessage;
+
+public interface NotificationSender {
+    void sendNotification(ChatMessage message);
+}

--- a/api/src/main/java/com/example/chat/service/SqsNotificationService.java
+++ b/api/src/main/java/com/example/chat/service/SqsNotificationService.java
@@ -8,26 +8,26 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 @Service
-public class SqsNotificationService {
+@Profile("!local")
+public class SqsNotificationService implements NotificationSender {
 
     private static final Logger log = LoggerFactory.getLogger(SqsNotificationService.class);
 
     private final SqsTemplate sqsTemplate;
     private final String queueName;
-    private final ApplicationEventPublisher eventPublisher;
 
     public SqsNotificationService(
-            ObjectProvider<SqsTemplate> sqsTemplateProvider,
-            @Value("${app.sqs.chat-message-queue:}") String queueName,
-            ApplicationEventPublisher eventPublisher) {
-        this.sqsTemplate = sqsTemplateProvider.getIfAvailable();
+            SqsTemplate sqsTemplate,
+            @Value("${app.sqs.chat-message-queue}") String queueName) {
+        this.sqsTemplate = sqsTemplate;
         this.queueName = queueName;
-        this.eventPublisher = eventPublisher;
     }
 
+    @Override
     public void sendNotification(ChatMessage message) {
         var event = new ChatNotificationEvent(
                 message.getId(),
@@ -38,12 +38,6 @@ public class SqsNotificationService {
                 message.getMessageType(),
                 message.getCreatedAt()
         );
-
-        if (sqsTemplate == null || queueName.isBlank()) {
-            log.debug("SQS is not configured, publishing local event for message {}", message.getId());
-            eventPublisher.publishEvent(event);
-            return;
-        }
 
         sqsTemplate.send(to -> to.queue(queueName).payload(event));
         log.info("Sent notification to SQS for message {} in room {}", message.getId(), message.getRoomId());

--- a/api/src/main/resources/application-local.yaml
+++ b/api/src/main/resources/application-local.yaml
@@ -17,6 +17,7 @@ spring:
   autoconfigure:
     exclude:
       - io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration
+      - io.awspring.cloud.autoconfigure.ses.SesAutoConfiguration
 
 app:
   s3:
@@ -24,3 +25,5 @@ app:
   sqs:
     queue-url: ""
     chat-message-queue: ""
+  ses:
+    from-address: ""

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -45,6 +45,8 @@ app:
   cognito:
     user-pool-id: ${COGNITO_USER_POOL_ID:}
     client-id: ${COGNITO_CLIENT_ID:}
+  ses:
+    from-address: ${SES_FROM_ADDRESS:noreply@tommykeyapp.com}
   webpush:
     vapid-public-key: ${VAPID_PUBLIC_KEY:}
     vapid-private-key: ${VAPID_PRIVATE_KEY:}

--- a/api/src/test/java/com/example/chat/integration/BaseIntegrationTest.java
+++ b/api/src/test/java/com/example/chat/integration/BaseIntegrationTest.java
@@ -2,7 +2,8 @@ package com.example.chat.integration;
 
 import com.example.chat.repository.ChatMessageSearchRepository;
 import com.example.chat.service.SearchService;
-import com.example.chat.service.SqsNotificationService;
+import com.example.chat.service.EmailNotificationService;
+import com.example.chat.service.NotificationSender;
 import com.example.chat.service.WebPushService;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,10 +47,13 @@ public abstract class BaseIntegrationTest {
     protected SearchService searchService;
 
     @MockitoBean
-    protected SqsNotificationService sqsNotificationService;
+    protected NotificationSender notificationSender;
 
     @MockitoBean
     protected WebPushService webPushService;
+
+    @MockitoBean
+    protected EmailNotificationService emailNotificationService;
 
     @MockitoBean
     protected ChatMessageSearchRepository chatMessageSearchRepository;

--- a/api/src/test/java/com/example/chat/service/ChatServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/ChatServiceTest.java
@@ -31,7 +31,7 @@ class ChatServiceTest {
     private SearchService searchService;
 
     @Mock
-    private SqsNotificationService sqsNotificationService;
+    private NotificationSender notificationSender;
 
     @InjectMocks
     private ChatService chatService;
@@ -85,14 +85,14 @@ class ChatServiceTest {
     }
 
     @Test
-    void saveMessage_callsSqsNotificationServiceSendNotification() {
+    void saveMessage_callsNotificationSenderSendNotification() {
         UUID roomId = UUID.randomUUID();
         ChatMessage savedMsg = buildSavedMessage(roomId);
         when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMsg);
 
         chatService.saveMessage(roomId, "user-1", "Alice", "Hello!", "TEXT");
 
-        verify(sqsNotificationService).sendNotification(savedMsg);
+        verify(notificationSender).sendNotification(savedMsg);
     }
 
     @Test
@@ -109,11 +109,11 @@ class ChatServiceTest {
     }
 
     @Test
-    void saveMessage_whenSqsNotificationServiceThrows_messageIsStillSavedAndReturned() {
+    void saveMessage_whenNotificationSenderThrows_messageIsStillSavedAndReturned() {
         UUID roomId = UUID.randomUUID();
         ChatMessage savedMsg = buildSavedMessage(roomId);
         when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMsg);
-        doThrow(new RuntimeException("SQS is down")).when(sqsNotificationService).sendNotification(any());
+        doThrow(new RuntimeException("SQS is down")).when(notificationSender).sendNotification(any());
 
         ChatMessage result = chatService.saveMessage(roomId, "user-1", "Alice", "Hello!", "TEXT");
 

--- a/api/src/test/java/com/example/chat/service/SqsNotificationServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/SqsNotificationServiceTest.java
@@ -1,23 +1,18 @@
 package com.example.chat.service;
 
-import com.example.chat.model.dto.ChatNotificationEvent;
 import com.example.chat.model.entity.ChatMessage;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.Instant;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class SqsNotificationServiceTest {
@@ -25,65 +20,14 @@ class SqsNotificationServiceTest {
     @Mock
     private SqsTemplate sqsTemplate;
 
-    @Mock
-    private ApplicationEventPublisher eventPublisher;
-
     @Test
-    void sendNotification_whenSqsConfigured_sendsToSqs() {
-        SqsNotificationService service = buildService(sqsTemplate, "chat-notifications");
+    void sendNotification_sendsToSqs() {
+        var service = new SqsNotificationService(sqsTemplate, "chat-messages");
         ChatMessage message = buildMessage();
 
         service.sendNotification(message);
 
         verify(sqsTemplate).send(any(Consumer.class));
-        verify(eventPublisher, never()).publishEvent(any());
-    }
-
-    @Test
-    void sendNotification_whenSqsTemplateIsNull_publishesLocalEvent() {
-        SqsNotificationService service = buildService(null, "chat-notifications");
-        ChatMessage message = buildMessage();
-
-        service.sendNotification(message);
-
-        verify(eventPublisher).publishEvent(any(ChatNotificationEvent.class));
-    }
-
-    @Test
-    void sendNotification_whenQueueNameIsBlank_publishesLocalEvent() {
-        SqsNotificationService service = buildService(sqsTemplate, "");
-        ChatMessage message = buildMessage();
-
-        service.sendNotification(message);
-
-        verify(eventPublisher).publishEvent(any(ChatNotificationEvent.class));
-        verify(sqsTemplate, never()).send(any(Consumer.class));
-    }
-
-    @Test
-    void sendNotification_eventHasCorrectFieldsMappedFromChatMessage() {
-        SqsNotificationService service = buildService(null, "");
-        ChatMessage message = buildMessage();
-
-        service.sendNotification(message);
-
-        ArgumentCaptor<ChatNotificationEvent> captor = ArgumentCaptor.forClass(ChatNotificationEvent.class);
-        verify(eventPublisher).publishEvent(captor.capture());
-        ChatNotificationEvent event = captor.getValue();
-        assertThat(event.messageId()).isEqualTo(message.getId());
-        assertThat(event.roomId()).isEqualTo(message.getRoomId());
-        assertThat(event.senderId()).isEqualTo(message.getSenderId());
-        assertThat(event.senderName()).isEqualTo(message.getSenderName());
-        assertThat(event.content()).isEqualTo(message.getContent());
-        assertThat(event.messageType()).isEqualTo(message.getMessageType());
-        assertThat(event.createdAt()).isEqualTo(message.getCreatedAt());
-    }
-
-    @SuppressWarnings("unchecked")
-    private SqsNotificationService buildService(SqsTemplate template, String queueName) {
-        ObjectProvider<SqsTemplate> provider = mock(ObjectProvider.class);
-        lenient().when(provider.getIfAvailable()).thenReturn(template);
-        return new SqsNotificationService(provider, queueName, eventPublisher);
     }
 
     private ChatMessage buildMessage() {

--- a/api/src/test/resources/application-test.yaml
+++ b/api/src/test/resources/application-test.yaml
@@ -13,6 +13,7 @@ spring:
   autoconfigure:
     exclude:
       - io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration
+      - io.awspring.cloud.autoconfigure.ses.SesAutoConfiguration
       - io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration
       - io.awspring.cloud.autoconfigure.core.CredentialsProviderAutoConfiguration
       - io.awspring.cloud.autoconfigure.core.RegionProviderAutoConfiguration
@@ -28,6 +29,8 @@ app:
   sqs:
     queue-url: ""
     chat-message-queue: ""
+  ses:
+    from-address: ""
   webpush:
     vapid-public-key: ""
     vapid-private-key: ""

--- a/infra/irsa.tf
+++ b/infra/irsa.tf
@@ -30,7 +30,7 @@ module "irsa_chat_api" {
 
 resource "aws_iam_policy" "chat_api_access" {
   name        = "${var.project}-api-access"
-  description = "Policy for chat API to access S3 and SQS"
+  description = "Policy for chat API to access S3, SQS, and SES"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -56,6 +56,15 @@ resource "aws_iam_policy" "chat_api_access" {
           "sqs:CreateQueue",
         ]
         Resource = aws_sqs_queue.chat_messages.arn
+      },
+      {
+        Sid    = "SESAccess"
+        Effect = "Allow"
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail",
+        ]
+        Resource = "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/tommykeyapp.com"
       },
     ]
   })

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -62,3 +62,8 @@ output "region" {
   description = "AWS region"
   value       = var.region
 }
+
+output "ses_domain_identity" {
+  description = "SES verified domain"
+  value       = aws_ses_domain_identity.chat.domain
+}

--- a/infra/ses.tf
+++ b/infra/ses.tf
@@ -1,0 +1,60 @@
+resource "aws_ses_domain_identity" "chat" {
+  domain = "tommykeyapp.com"
+}
+
+resource "aws_ses_domain_dkim" "chat" {
+  domain = aws_ses_domain_identity.chat.domain
+}
+
+resource "aws_ses_domain_mail_from" "chat" {
+  domain           = aws_ses_domain_identity.chat.domain
+  mail_from_domain = "mail.tommykeyapp.com"
+
+  behavior_on_mx_failure = "UseDefaultValue"
+}
+
+# Domain verification TXT record
+resource "aws_route53_record" "ses_verification" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "_amazonses.tommykeyapp.com"
+  type    = "TXT"
+  ttl     = 600
+  records = [aws_ses_domain_identity.chat.verification_token]
+}
+
+# DKIM CNAME records (3 records)
+resource "aws_route53_record" "ses_dkim" {
+  count   = 3
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "${aws_ses_domain_dkim.chat.dkim_tokens[count.index]}._domainkey.tommykeyapp.com"
+  type    = "CNAME"
+  ttl     = 600
+  records = ["${aws_ses_domain_dkim.chat.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}
+
+# MAIL FROM: MX record
+resource "aws_route53_record" "ses_mail_from_mx" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "mail.tommykeyapp.com"
+  type    = "MX"
+  ttl     = 600
+  records = ["10 feedback-smtp.${var.region}.amazonses.com"]
+}
+
+# MAIL FROM: SPF TXT record
+resource "aws_route53_record" "ses_mail_from_spf" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "mail.tommykeyapp.com"
+  type    = "TXT"
+  ttl     = 600
+  records = ["v=spf1 include:amazonses.com ~all"]
+}
+
+# DMARC TXT record
+resource "aws_route53_record" "ses_dmarc" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "_dmarc.tommykeyapp.com"
+  type    = "TXT"
+  ttl     = 600
+  records = ["v=DMARC1; p=quarantine; adkim=r; aspf=r"]
+}

--- a/manifests/base/configmap.yaml
+++ b/manifests/base/configmap.yaml
@@ -16,3 +16,4 @@ data:
   COGNITO_CLIENT_ID: 7vsovq6esg1am78jmk3diucc3q
   APP_SQS_CHAT_MESSAGE_QUEUE: chat-messages
   SPRING_ELASTICSEARCH_URIS: http://elasticsearch:9200
+  SES_FROM_ADDRESS: noreply@tommykeyapp.com


### PR DESCRIPTION
## Summary
- SQSのフォールバック（ApplicationEventPublisher）を削除し、SQSを通知パイプラインの**唯一の経路**に変更
- `NotificationSender` インターフェースを導入し、本番(`SqsNotificationService`)とローカル(`LocalNotificationSender`)を `@Profile` で切り替え
- `EmailNotificationService` を新規追加: 未読5件以上溜まったユーザーにSES経由でメール通知（Redis cooldownで1時間に1回まで）
- Terraform: SESドメインID + Easy DKIM + Custom MAIL FROM + DMARC + Route 53 DNSレコード
- IAMポリシーに `ses:SendEmail` / `ses:SendRawEmail` を追加

## Architecture

```
メッセージ送信 → SQS (唯一の経路、フォールバックなし)
  → SQS Consumer:
    1. STOMP WebSocket通知 (既存)
    2. Web Push通知 (既存)
    3. SESメール通知 (新規: 未読≥5件 & cooldown 1h)
```

## Files changed

| カテゴリ | ファイル | 変更 |
|---------|---------|------|
| Interface | `NotificationSender.java` | 新規: 共通インターフェース |
| Production | `SqsNotificationService.java` | フォールバック削除、`@Profile("!local")` |
| Local | `LocalNotificationSender.java` | 新規: ローカル用 EventPublisher 実装 |
| Email | `EmailNotificationService.java` | 新規: 未読数チェック → SES送信 |
| Listener | `SqsMessageListener.java` | EmailNotificationService 呼び出し追加 |
| Listener | `LocalNotificationListener.java` | 同上 |
| Service | `ChatService.java` | NotificationSender インターフェースに切替 |
| Infra | `ses.tf` | 新規: SES + DKIM + MAIL FROM + DNS |
| Infra | `irsa.tf` | SES送信権限追加 |
| Config | `configmap.yaml` | SES_FROM_ADDRESS 追加 |

## Test plan
- [x] `./gradlew test` 全テスト通過
- [ ] `terraform plan` で SES 関連リソースが追加されること
- [ ] SES サンドボックスで検証メール送信テスト
- [ ] 本番デプロイ後、未読5件以上でメール受信確認

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)