### PR TITLE
feat: Elasticsearch強化 — kuromoji + PV永続化 + 横断検索

### DIFF
--- a/api/src/main/java/com/example/chat/controller/SearchController.java
+++ b/api/src/main/java/com/example/chat/controller/SearchController.java
@@ -1,0 +1,24 @@
+package com.example.chat.controller;
+
+import com.example.chat.model.dto.SearchResponse;
+import com.example.chat.service.SearchService;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/messages")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    public SearchController(SearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    @GetMapping("/search")
+    public Page<SearchResponse> searchAllRooms(@RequestParam String q,
+                                                @RequestParam(defaultValue = "0") int page,
+                                                @RequestParam(defaultValue = "20") int size) {
+        return searchService.searchAllRooms(q, page, size);
+    }
+}

--- a/api/src/main/java/com/example/chat/model/dto/SearchResponse.java
+++ b/api/src/main/java/com/example/chat/model/dto/SearchResponse.java
@@ -1,0 +1,15 @@
+package com.example.chat.model.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record SearchResponse(
+        UUID id,
+        UUID roomId,
+        String senderId,
+        String senderName,
+        String content,
+        String highlightedContent,
+        String messageType,
+        Instant createdAt
+) {}

--- a/api/src/main/java/com/example/chat/model/entity/ChatMessageDocument.java
+++ b/api/src/main/java/com/example/chat/model/entity/ChatMessageDocument.java
@@ -4,10 +4,12 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
 
 import java.time.Instant;
 
 @Document(indexName = "chat-messages")
+@Setting(settingPath = "elasticsearch/settings.json")
 public class ChatMessageDocument {
 
     @Id
@@ -22,7 +24,7 @@ public class ChatMessageDocument {
     @Field(type = FieldType.Text)
     private String senderName;
 
-    @Field(type = FieldType.Text, analyzer = "standard")
+    @Field(type = FieldType.Text, analyzer = "kuromoji_analyzer")
     private String content;
 
     @Field(type = FieldType.Keyword)

--- a/api/src/main/java/com/example/chat/service/SearchService.java
+++ b/api/src/main/java/com/example/chat/service/SearchService.java
@@ -1,23 +1,36 @@
 package com.example.chat.service;
 
 import com.example.chat.model.dto.MessageResponse;
+import com.example.chat.model.dto.SearchResponse;
 import com.example.chat.model.entity.ChatMessage;
 import com.example.chat.model.entity.ChatMessageDocument;
 import com.example.chat.repository.ChatMessageSearchRepository;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.HighlightQuery;
+import org.springframework.data.elasticsearch.core.query.highlight.Highlight;
+import org.springframework.data.elasticsearch.core.query.highlight.HighlightField;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
 public class SearchService {
 
     private final ChatMessageSearchRepository searchRepository;
+    private final ElasticsearchOperations elasticsearchOperations;
 
-    public SearchService(ChatMessageSearchRepository searchRepository) {
+    public SearchService(ChatMessageSearchRepository searchRepository,
+                         ElasticsearchOperations elasticsearchOperations) {
         this.searchRepository = searchRepository;
+        this.elasticsearchOperations = elasticsearchOperations;
     }
 
     public void indexMessage(ChatMessage message) {
@@ -36,5 +49,43 @@ public class SearchService {
                         doc.getMessageType(),
                         doc.getCreatedAt()
                 ));
+    }
+
+    public Page<SearchResponse> searchAllRooms(String query, int page, int size) {
+        var pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        var highlight = new Highlight(List.of(new HighlightField("content")));
+
+        var nativeQuery = NativeQuery.builder()
+                .withQuery(q -> q.match(m -> m.field("content").query(query)))
+                .withHighlightQuery(new HighlightQuery(highlight, null))
+                .withPageable(pageable)
+                .build();
+
+        SearchHits<ChatMessageDocument> hits = elasticsearchOperations.search(
+                nativeQuery, ChatMessageDocument.class);
+
+        var results = hits.getSearchHits().stream()
+                .map(this::toSearchResponse)
+                .toList();
+
+        return new PageImpl<>(results, pageable, hits.getTotalHits());
+    }
+
+    private SearchResponse toSearchResponse(SearchHit<ChatMessageDocument> hit) {
+        var doc = hit.getContent();
+        var highlightedContent = hit.getHighlightFields().containsKey("content")
+                ? String.join(" ... ", hit.getHighlightFields().get("content"))
+                : doc.getContent();
+
+        return new SearchResponse(
+                UUID.fromString(doc.getId()),
+                UUID.fromString(doc.getRoomId()),
+                doc.getSenderId(),
+                doc.getSenderName(),
+                doc.getContent(),
+                highlightedContent,
+                doc.getMessageType(),
+                doc.getCreatedAt()
+        );
     }
 }

--- a/api/src/main/resources/elasticsearch/settings.json
+++ b/api/src/main/resources/elasticsearch/settings.json
@@ -1,0 +1,16 @@
+{
+  "analysis": {
+    "analyzer": {
+      "kuromoji_analyzer": {
+        "type": "custom",
+        "tokenizer": "kuromoji_tokenizer",
+        "filter": [
+          "kuromoji_baseform",
+          "kuromoji_part_of_speech",
+          "cjk_width",
+          "lowercase"
+        ]
+      }
+    }
+  }
+}

--- a/manifests/base/elasticsearch.yaml
+++ b/manifests/base/elasticsearch.yaml
@@ -15,6 +15,13 @@ spec:
       labels:
         app: elasticsearch
     spec:
+      initContainers:
+        - name: install-plugins
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+          command: ["bin/elasticsearch-plugin", "install", "--batch", "analysis-kuromoji"]
+          volumeMounts:
+            - name: plugins
+              mountPath: /usr/share/elasticsearch/plugins
       containers:
         - name: elasticsearch
           image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
@@ -27,6 +34,11 @@ spec:
               value: "false"
             - name: ES_JAVA_OPTS
               value: "-Xms256m -Xmx256m"
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+            - name: plugins
+              mountPath: /usr/share/elasticsearch/plugins
           resources:
             requests:
               cpu: 200m
@@ -40,6 +52,24 @@ spec:
               port: 9200
             initialDelaySeconds: 30
             periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: elasticsearch-data
+        - name: plugins
+          emptyDir: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: elasticsearch-data
+  namespace: chat
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
 ---
 apiVersion: v1
 kind: Service

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -69,6 +69,20 @@ export const getMessages = (roomId: string, page = 0, size = 50) =>
 export const searchMessages = (roomId: string, query: string, page = 0, size = 50) =>
 	request<PageResponse<Message>>('GET', `/api/rooms/${roomId}/messages/search?q=${encodeURIComponent(query)}&page=${page}&size=${size}`);
 
+export interface SearchResult {
+	id: string;
+	roomId: string;
+	senderId: string;
+	senderName: string;
+	content: string;
+	highlightedContent: string;
+	messageType: string;
+	createdAt: string;
+}
+
+export const searchAllMessages = (query: string, page = 0, size = 20) =>
+	request<PageResponse<SearchResult>>('GET', `/api/messages/search?q=${encodeURIComponent(query)}&page=${page}&size=${size}`);
+
 export const getUploadUrl = (roomId: string, fileName: string, contentType: string) =>
 	request<{ uploadUrl: string; s3Key: string }>('POST', '/api/files/presign-upload', { roomId, fileName, contentType });
 

--- a/web/src/routes/rooms/+page.svelte
+++ b/web/src/routes/rooms/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { listRooms, createRoom, joinRoom, type Room } from '$lib/api';
+	import { listRooms, createRoom, joinRoom, searchAllMessages, type Room, type SearchResult } from '$lib/api';
 	import { getAuthState, logout } from '$lib/stores/auth.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
@@ -17,6 +17,28 @@
 	let newDesc = $state('');
 	let loading = $state(false);
 	let error = $state('');
+	let showSearch = $state(false);
+	let searchQuery = $state('');
+	let searchResults = $state<SearchResult[]>([]);
+	let searching = $state(false);
+
+	async function handleSearch() {
+		if (!searchQuery.trim()) return;
+		searching = true;
+		try {
+			const res = await searchAllMessages(searchQuery);
+			searchResults = res.content;
+		} catch {
+			searchResults = [];
+		} finally {
+			searching = false;
+		}
+	}
+
+	function getRoomName(roomId: string): string {
+		const room = rooms.find(r => r.id === roomId);
+		return room ? room.name : 'Unknown';
+	}
 
 	async function loadRooms() {
 		try {
@@ -56,6 +78,7 @@
 			<a href="/profile" class="text-xs text-muted-foreground hover:text-foreground sm:text-sm">設定</a>
 		</div>
 		<div class="flex items-center gap-1 sm:gap-2">
+			<Button size="sm" variant="ghost" onclick={() => { showSearch = !showSearch; if (!showSearch) { searchQuery = ''; searchResults = []; } }}>検索</Button>
 			<Button size="sm" onclick={() => (showCreate = !showCreate)}>+</Button>
 			<button
 				onclick={() => { logout(); goto('/login'); }}
@@ -65,6 +88,35 @@
 			</button>
 		</div>
 	</header>
+
+	{#if showSearch}
+		<div class="mx-auto w-full max-w-2xl px-4 pt-4 sm:px-6">
+			<form onsubmit={(e) => { e.preventDefault(); handleSearch(); }} class="flex gap-2">
+				<Input bind:value={searchQuery} placeholder="全ルーム横断検索..." class="flex-1" />
+				<Button type="submit" disabled={searching}>{searching ? '検索中...' : '検索'}</Button>
+			</form>
+			{#if searchResults.length > 0}
+				<div class="mt-3 flex flex-col gap-2">
+					{#each searchResults as result (result.id)}
+						<a href="/rooms/{result.roomId}" class="block">
+							<Card.Root class="py-2 gap-1 transition hover:border-primary/30 hover:bg-card/80">
+								<Card.Content>
+									<div class="flex items-center gap-2 text-xs text-muted-foreground">
+										<span class="text-primary font-medium">#{getRoomName(result.roomId)}</span>
+										<span>{result.senderName}</span>
+										<span>{new Date(result.createdAt).toLocaleString('ja-JP', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span>
+									</div>
+									<p class="mt-1 text-sm">{@html result.highlightedContent}</p>
+								</Card.Content>
+							</Card.Root>
+						</a>
+					{/each}
+				</div>
+			{:else if searchQuery && !searching}
+				<p class="mt-3 text-center text-sm text-muted-foreground">結果なし</p>
+			{/if}
+		</div>
+	{/if}
 
 	<main class="mx-auto w-full max-w-2xl flex-1 px-4 py-6 sm:px-6">
 		<Dialog.Root bind:open={showCreate}>


### PR DESCRIPTION
## Summary
- **kuromoji analyzer** 導入: 日本語形態素解析で「テストメッセージ」→「テスト」「メッセージ」に分かち書きして検索可能に
- **PersistentVolumeClaim** 追加: 5Gi の永続ストレージで Pod 再起動時もインデックス保持
- **全ルーム横断検索 API**: `GET /api/messages/search?q=...` — roomId 不要で全ルームを横断検索
- **ハイライト**: 検索結果のマッチ箇所を `<em>` タグで強調して返却
- **フロントエンド**: ルーム一覧ヘッダーに「検索」ボタン → 横断検索パネル展開

## Why
これまでの ES は PostgreSQL LIKE で代替可能な単純検索のみだった。kuromoji + 横断検索 + ハイライトにより「ES でなければ実現できない」機能に強化。

## Architecture
```
ユーザーが検索
  → GET /api/messages/search?q=テスト
  → SearchService.searchAllRooms()
    → NativeQuery + HighlightQuery
    → kuromoji_analyzer でトークン化
    → 全ルーム横断で検索 + ハイライト抽出
  → SearchResponse (content + highlightedContent)
```

## Changes
| ファイル | 変更 |
|---------|------|
| `elasticsearch.yaml` | initContainer で kuromoji プラグインインストール + PVC 追加 |
| `settings.json` | 新規: kuromoji analyzer 設定 |
| `ChatMessageDocument.java` | `@Setting` + analyzer を kuromoji_analyzer に変更 |
| `SearchService.java` | `searchAllRooms()` 追加 (NativeQuery + ハイライト) |
| `SearchController.java` | 新規: `GET /api/messages/search` |
| `SearchResponse.java` | 新規: ハイライト付き検索結果 DTO |
| `api.ts` | `searchAllMessages()` + `SearchResult` interface 追加 |
| `rooms/+page.svelte` | 横断検索 UI 追加 |

## Test plan
- [x] `./gradlew test` 全テスト通過
- [x] `pnpm build` ビルド成功
- [ ] kuromoji プラグインが ES に入っていることを確認
- [ ] 日本語メッセージの横断検索でマッチすることを確認
- [ ] ハイライト付きの結果が返ることを確認

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)