### PR TITLE
fix: CDパイプラインのgit push権限エラーを修正

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,6 +9,9 @@ on:
       - "infra/**"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   AWS_REGION: ap-northeast-1
   ECR_REPOSITORY: chat-api


### PR DESCRIPTION
## Summary
- `deploy-api` ジョブの `git push` が `403 Permission denied` で失敗していた
- ワークフローに `permissions: contents: write` を追加して GITHUB_TOKEN に書き込み権限を付与

## Root cause
`actions/checkout@v4` のデフォルト GITHUB_TOKEN は `contents: read` のみ。#59 で追加した kustomization.yaml の git push ステップに書き込み権限が必要だった。

## Test plan
- [ ] CD ワークフローが deploy-api で `git push` に成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)