### PR TITLE
feat: S3 → Lambda サムネイル自動生成

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,6 +7,7 @@ on:
       - "api/**"
       - "web/**"
       - "infra/**"
+      - "lambda/**"
   workflow_dispatch:
 
 permissions:
@@ -28,6 +29,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build Lambda thumbnail
+        run: |
+          cd lambda/thumbnail
+          npm ci
+          zip -r ../../infra/lambda-thumbnail.zip .
 
       - uses: hashicorp/setup-terraform@v3
 

--- a/api/src/main/java/com/example/chat/controller/FileController.java
+++ b/api/src/main/java/com/example/chat/controller/FileController.java
@@ -31,4 +31,11 @@ public class FileController {
         String downloadUrl = fileService.generateDownloadUrl(s3Key);
         return Map.of("downloadUrl", downloadUrl);
     }
+
+    @GetMapping("/presign-download-thumb/**")
+    public Map<String, String> presignDownloadThumb(jakarta.servlet.http.HttpServletRequest request) {
+        String s3Key = request.getRequestURI().replaceFirst("/api/files/presign-download-thumb/", "");
+        String downloadUrl = fileService.generateThumbnailDownloadUrl(s3Key);
+        return Map.of("downloadUrl", downloadUrl);
+    }
 }

--- a/api/src/main/java/com/example/chat/service/FileService.java
+++ b/api/src/main/java/com/example/chat/service/FileService.java
@@ -43,6 +43,14 @@ public class FileService {
         return new PresignedUrlResponse(presignedRequest.url().toString(), s3Key);
     }
 
+    public String getThumbnailKey(String s3Key) {
+        return s3Key.replaceAll("(\\.[^.]+)$", "_thumb$1");
+    }
+
+    public String generateThumbnailDownloadUrl(String s3Key) {
+        return generateDownloadUrl(getThumbnailKey(s3Key));
+    }
+
     public String generateDownloadUrl(String s3Key) {
         var getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -1,0 +1,83 @@
+resource "aws_iam_role" "thumbnail_lambda" {
+  name = "${var.project}-thumbnail-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_iam_role_policy" "thumbnail_lambda" {
+  name = "${var.project}-thumbnail-lambda-policy"
+  role = aws_iam_role.thumbnail_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3Access"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+        ]
+        Resource = "${aws_s3_bucket.chat_uploads.arn}/*"
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*"
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "thumbnail" {
+  filename         = "${path.module}/lambda-thumbnail.zip"
+  function_name    = "${var.project}-thumbnail"
+  role             = aws_iam_role.thumbnail_lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs22.x"
+  timeout          = 30
+  memory_size      = 512
+  source_code_hash = filebase64sha256("${path.module}/lambda-thumbnail.zip")
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_lambda_permission" "s3_invoke" {
+  statement_id  = "AllowS3Invoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.thumbnail.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.chat_uploads.arn
+}
+
+resource "aws_s3_bucket_notification" "uploads" {
+  bucket = aws_s3_bucket.chat_uploads.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.thumbnail.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "uploads/"
+  }
+}

--- a/lambda/thumbnail/index.mjs
+++ b/lambda/thumbnail/index.mjs
@@ -1,0 +1,36 @@
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import sharp from 'sharp';
+
+const s3 = new S3Client();
+const THUMB_WIDTH = 400;
+
+export const handler = async (event) => {
+  const bucket = event.Records[0].s3.bucket.name;
+  const key = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
+
+  // サムネイルは処理しない（無限ループ防止）
+  if (key.includes('_thumb')) return;
+
+  // 画像のみ処理
+  const ext = key.split('.').pop().toLowerCase();
+  if (!['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(ext)) return;
+
+  console.log(`Processing thumbnail for: ${key}`);
+
+  const { Body, ContentType } = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+  const buffer = Buffer.from(await Body.transformToByteArray());
+
+  const thumbnail = await sharp(buffer)
+    .resize(THUMB_WIDTH)
+    .toBuffer();
+
+  const thumbKey = key.replace(/(\.[^.]+)$/, '_thumb$1');
+  await s3.send(new PutObjectCommand({
+    Bucket: bucket,
+    Key: thumbKey,
+    Body: thumbnail,
+    ContentType
+  }));
+
+  console.log(`Thumbnail created: ${thumbKey}`);
+};

--- a/lambda/thumbnail/package.json
+++ b/lambda/thumbnail/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "thumbnail-generator",
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
+    "sharp": "^0.33.0"
+  }
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -89,6 +89,9 @@ export const getUploadUrl = (roomId: string, fileName: string, contentType: stri
 export const getDownloadUrl = (s3Key: string) =>
 	request<{ downloadUrl: string }>('GET', `/api/files/presign-download/${s3Key}`);
 
+export const getThumbnailUrl = (s3Key: string) =>
+	request<{ downloadUrl: string }>('GET', `/api/files/presign-download-thumb/${s3Key}`);
+
 // Users
 export interface UserInfo {
 	id: string;

--- a/web/src/routes/rooms/[roomId]/+page.svelte
+++ b/web/src/routes/rooms/[roomId]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import { getMessages, getRoom, getUploadUrl, getDownloadUrl, leaveRoom, deleteRoom, searchMessages, getReadStatus, getRoomMembers, editMessage, deleteMessage, addReaction, removeReaction, type Message, type Room, type ReactionGroup } from '$lib/api';
+	import { getMessages, getRoom, getUploadUrl, getDownloadUrl, getThumbnailUrl, leaveRoom, deleteRoom, searchMessages, getReadStatus, getRoomMembers, editMessage, deleteMessage, addReaction, removeReaction, type Message, type Room, type ReactionGroup } from '$lib/api';
 	import { getAuthState } from '$lib/stores/auth.svelte';
 	import { untrack } from 'svelte';
 	import { subscribe, send, getWsState } from '$lib/websocket.svelte';
@@ -19,6 +19,8 @@
 	let searchResults = $state<Message[]>([]);
 	let searching = $state(false);
 	let imageUrls = $state<Record<string, string>>({});
+	let fullImageUrls = $state<Record<string, string>>({});
+	let lightboxUrl = $state<string | null>(null);
 	let currentPage = 0;
 	let totalPages = 1;
 	let loadingMore = $state(false);
@@ -242,11 +244,30 @@
 	async function resolveImageUrl(msg: Message) {
 		if (msg.messageType === 'IMAGE' && !imageUrls[msg.id]) {
 			try {
-				const { downloadUrl } = await getDownloadUrl(msg.content);
+				const { downloadUrl } = await getThumbnailUrl(msg.content);
 				imageUrls = { ...imageUrls, [msg.id]: downloadUrl };
 			} catch {
-				// ignore
+				try {
+					const { downloadUrl } = await getDownloadUrl(msg.content);
+					imageUrls = { ...imageUrls, [msg.id]: downloadUrl };
+				} catch {
+					// ignore
+				}
 			}
+		}
+	}
+
+	async function openLightbox(msg: Message) {
+		if (fullImageUrls[msg.id]) {
+			lightboxUrl = fullImageUrls[msg.id];
+			return;
+		}
+		try {
+			const { downloadUrl } = await getDownloadUrl(msg.content);
+			fullImageUrls = { ...fullImageUrls, [msg.id]: downloadUrl };
+			lightboxUrl = downloadUrl;
+		} catch {
+			// ignore
 		}
 	}
 
@@ -386,7 +407,9 @@
 						<p class="text-xs italic text-muted-foreground">{msg.content}</p>
 					{:else if msg.messageType === 'IMAGE'}
 						{#if imageUrls[msg.id]}
-							<img src={imageUrls[msg.id]} alt="画像" class="max-w-full rounded" loading="lazy" />
+							<button onclick={() => openLightbox(msg)} class="cursor-pointer">
+								<img src={imageUrls[msg.id]} alt="画像" class="max-w-full rounded" loading="lazy" />
+							</button>
 						{:else}
 							<p class="text-sm text-muted-foreground">読み込み中...</p>
 						{/if}
@@ -479,4 +502,13 @@
 			</button>
 		</div>
 	</div>
+
+	{#if lightboxUrl}
+		<button
+			onclick={() => (lightboxUrl = null)}
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+		>
+			<img src={lightboxUrl} alt="原寸画像" class="max-h-[90vh] max-w-[90vw] rounded" />
+		</button>
+	{/if}
 </div>


### PR DESCRIPTION
## Summary
- **Lambda関数**: Node.js 22 + sharp で画像アップロード時に 400px サムネイルを自動生成
- **S3 Event Notification**: `uploads/` プレフィックスの ObjectCreated イベントで Lambda をトリガー
- **サムネイル表示**: チャット画面でサムネイルを表示、クリックで原寸画像をライトボックス表示
- **CDパイプライン**: deploy-infra に Lambda ビルド + zip ステップを追加

## Architecture
```
ユーザーが画像アップロード（presigned URL → S3）
  → S3 Event Notification → Lambda
    → sharp で 400px にリサイズ
    → S3 に photo_thumb.jpg として保存
  → フロントは _thumb 付きの presigned URL でサムネイル表示
  → クリックで原寸画像をモーダル表示
```

## Files changed
| ファイル | 変更 |
|---------|------|
| `lambda/thumbnail/index.mjs` | 新規: サムネイル生成 Lambda |
| `lambda/thumbnail/package.json` | 新規: sharp 依存 |
| `infra/lambda.tf` | 新規: Lambda + IAM + S3 Event Notification |
| `FileService.java` | `getThumbnailKey()` + `generateThumbnailDownloadUrl()` 追加 |
| `FileController.java` | `GET /api/files/presign-download-thumb/**` 追加 |
| `api.ts` | `getThumbnailUrl()` 追加 |
| `+page.svelte` | サムネイル表示 + ライトボックスモーダル |
| `cd.yaml` | Lambda ビルドステップ + paths に `lambda/**` 追加 |

## Test plan
- [x] `./gradlew test` 全テスト通過
- [x] `pnpm build` ビルド成功
- [ ] Lambda に画像をアップロードしてサムネイルが生成されること
- [ ] チャット画面でサムネイルが表示され、クリックで原寸表示されること

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)