### PR TITLE
feat: CloudFront signed URLでファイルダウンロード配信

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")
     implementation("io.awspring.cloud:spring-cloud-aws-starter-ses")
     implementation("software.amazon.awssdk:s3")
+    implementation("software.amazon.awssdk:cloudfront")
     implementation("software.amazon.awssdk:sts")
 
     // OpenAPI

--- a/api/src/main/java/com/example/chat/service/FileService.java
+++ b/api/src/main/java/com/example/chat/service/FileService.java
@@ -1,27 +1,42 @@
 package com.example.chat.service;
 
 import com.example.chat.model.dto.PresignedUrlResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.cloudfront.CloudFrontUtilities;
+import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
-import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 
 @Service
 public class FileService {
 
+    private static final Logger log = LoggerFactory.getLogger(FileService.class);
+
     private final S3Presigner s3Presigner;
     private final String bucketName;
+    private final String cloudfrontDomain;
+    private final String keyPairId;
+    private final String privateKeyPath;
 
     public FileService(S3Presigner s3Presigner,
-                       @Value("${app.s3.bucket}") String bucketName) {
+                       @Value("${app.s3.bucket}") String bucketName,
+                       @Value("${app.cloudfront.domain:}") String cloudfrontDomain,
+                       @Value("${app.cloudfront.key-pair-id:}") String keyPairId,
+                       @Value("${app.cloudfront.private-key-path:}") String privateKeyPath) {
         this.s3Presigner = s3Presigner;
         this.bucketName = bucketName;
+        this.cloudfrontDomain = cloudfrontDomain;
+        this.keyPairId = keyPairId;
+        this.privateKeyPath = privateKeyPath;
     }
 
     public PresignedUrlResponse generateUploadUrl(UUID roomId, String fileName, String contentType) {
@@ -52,18 +67,48 @@ public class FileService {
     }
 
     public String generateDownloadUrl(String s3Key) {
-        var getObjectRequest = GetObjectRequest.builder()
+        if (!cloudfrontDomain.isBlank() && !keyPairId.isBlank() && !privateKeyPath.isBlank()) {
+            return generateCloudFrontSignedUrl(s3Key);
+        }
+        return generateS3PresignedUrl(s3Key);
+    }
+
+    private String generateCloudFrontSignedUrl(String s3Key) {
+        try {
+            String resourceUrl = "https://" + cloudfrontDomain + "/" + s3Key;
+            Instant expiry = Instant.now().plus(Duration.ofHours(1));
+
+            CannedSignerRequest request = CannedSignerRequest.builder()
+                    .resourceUrl(resourceUrl)
+                    .privateKey(Path.of(privateKeyPath))
+                    .keyPairId(keyPairId)
+                    .expirationDate(expiry)
+                    .build();
+
+            String signedUrl = CloudFrontUtilities.create()
+                    .getSignedUrlWithCannedPolicy(request)
+                    .url();
+
+            log.debug("Generated CloudFront signed URL for {}", s3Key);
+            return signedUrl;
+        } catch (Exception e) {
+            log.warn("CloudFront signing failed, falling back to S3 presigned URL: {}", e.getMessage());
+            return generateS3PresignedUrl(s3Key);
+        }
+    }
+
+    private String generateS3PresignedUrl(String s3Key) {
+        var getObjectRequest = software.amazon.awssdk.services.s3.model.GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(s3Key)
                 .build();
 
-        var presignRequest = GetObjectPresignRequest.builder()
+        var presignRequest = software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest.builder()
                 .signatureDuration(Duration.ofHours(1))
                 .getObjectRequest(getObjectRequest)
                 .build();
 
         var presignedRequest = s3Presigner.presignGetObject(presignRequest);
-
         return presignedRequest.url().toString();
     }
 }

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -45,6 +45,10 @@ app:
   cognito:
     user-pool-id: ${COGNITO_USER_POOL_ID:}
     client-id: ${COGNITO_CLIENT_ID:}
+  cloudfront:
+    domain: ${CLOUDFRONT_DOMAIN:}
+    key-pair-id: ${CF_KEY_PAIR_ID:}
+    private-key-path: ${CF_PRIVATE_KEY_PATH:}
   ses:
     from-address: ${SES_FROM_ADDRESS:noreply@tommykeyapp.com}
   webpush:

--- a/api/src/test/java/com/example/chat/service/FileServiceTest.java
+++ b/api/src/test/java/com/example/chat/service/FileServiceTest.java
@@ -37,7 +37,7 @@ class FileServiceTest {
     private FileService fileService;
 
     private FileService createFileService() {
-        return new FileService(s3Presigner, bucketName);
+        return new FileService(s3Presigner, bucketName, "", "", "");
     }
 
     @Test

--- a/infra/cloudfront-key.tf
+++ b/infra/cloudfront-key.tf
@@ -1,0 +1,25 @@
+resource "tls_private_key" "cf_signing" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "aws_cloudfront_public_key" "signing" {
+  name        = "${var.project}-cf-signing-key"
+  encoded_key = tls_private_key.cf_signing.public_key_pem
+}
+
+resource "aws_cloudfront_key_group" "signing" {
+  name  = "${var.project}-cf-key-group"
+  items = [aws_cloudfront_public_key.signing.id]
+}
+
+resource "kubernetes_secret" "cf_signing_key" {
+  metadata {
+    name      = "cf-signing-key"
+    namespace = "chat"
+  }
+
+  data = {
+    "private-key" = tls_private_key.cf_signing.private_key_pem
+  }
+}

--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -23,6 +23,13 @@ resource "aws_cloudfront_origin_access_control" "frontend" {
   signing_protocol                  = "sigv4"
 }
 
+resource "aws_cloudfront_origin_access_control" "uploads" {
+  name                              = "${var.project}-uploads-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
 resource "aws_cloudfront_distribution" "chat" {
   enabled             = true
   default_root_object = "index.html"
@@ -34,6 +41,13 @@ resource "aws_cloudfront_distribution" "chat" {
     domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
     origin_id                = "s3-frontend"
     origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  # S3 origin for uploads (signed URL)
+  origin {
+    domain_name              = aws_s3_bucket.chat_uploads.bucket_regional_domain_name
+    origin_id                = "s3-uploads"
+    origin_access_control_id = aws_cloudfront_origin_access_control.uploads.id
   }
 
   # ALB origin for API
@@ -55,6 +69,28 @@ resource "aws_cloudfront_distribution" "chat" {
     cached_methods         = ["GET", "HEAD"]
     target_origin_id       = "s3-frontend"
     viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  # /uploads/* behavior: S3 uploads, signed URL required
+  ordered_cache_behavior {
+    path_pattern           = "/uploads/*"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "s3-uploads"
+    viewer_protocol_policy = "redirect-to-https"
+    trusted_key_groups     = [aws_cloudfront_key_group.signing.id]
 
     forwarded_values {
       query_string = false

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -63,6 +63,11 @@ output "region" {
   value       = var.region
 }
 
+output "cf_key_pair_id" {
+  description = "CloudFront signing key pair ID"
+  value       = aws_cloudfront_public_key.signing.id
+}
+
 output "ses_domain_identity" {
   description = "SES verified domain"
   value       = aws_ses_domain_identity.chat.domain

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -31,6 +31,30 @@ resource "aws_s3_bucket_lifecycle_configuration" "chat_uploads" {
   }
 }
 
+resource "aws_s3_bucket_policy" "chat_uploads" {
+  bucket = aws_s3_bucket.chat_uploads.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontOAC"
+        Effect    = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.chat_uploads.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.chat.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_s3_bucket_cors_configuration" "chat_uploads" {
   bucket = aws_s3_bucket.chat_uploads.id
 

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
 }
 

--- a/manifests/base/configmap.yaml
+++ b/manifests/base/configmap.yaml
@@ -16,4 +16,6 @@ data:
   COGNITO_CLIENT_ID: 7vsovq6esg1am78jmk3diucc3q
   APP_SQS_CHAT_MESSAGE_QUEUE: chat-messages
   SPRING_ELASTICSEARCH_URIS: http://elasticsearch:9200
+  CLOUDFRONT_DOMAIN: chat.tommykeyapp.com
+  CF_PRIVATE_KEY_PATH: /etc/cf-signing/private-key
   SES_FROM_ADDRESS: noreply@tommykeyapp.com

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -30,6 +30,16 @@ spec:
                 secretKeyRef:
                   name: chat-api-secret
                   key: db-password
+            - name: CF_KEY_PAIR_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cf-signing-key
+                  key: key-pair-id
+                  optional: true
+          volumeMounts:
+            - name: cf-signing-key
+              mountPath: /etc/cf-signing
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /actuator/health
@@ -50,3 +60,8 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+      volumes:
+        - name: cf-signing-key
+          secret:
+            secretName: cf-signing-key
+            optional: true


### PR DESCRIPTION
## Summary
- CloudFront 署名キー (RSA 2048) + Key Group + K8s Secret を Terraform で作成
- uploads バケットを CloudFront origin に追加 (OAC でプライベートアクセス)
- `/uploads/*` パスに trusted_key_groups で署名付きURLのみアクセス可能
- FileService のダウンロード URL を CloudFront signed URL に変更
- CloudFront 未設定時は S3 presigned URL にフォールバック（ローカル開発対応）

## Why
S3 presigned URL → CloudFront signed URL に変更することで:
- エッジキャッシュで高速配信
- S3 を完全プライベート化（OAC）
- HTTP/2, HTTP/3 対応

## Test plan
- [x] `./gradlew test` 全テスト通過
- [ ] `terraform plan` で CloudFront key + origin + バケットポリシーが追加されること
- [ ] ダウンロード URL が `https://chat.tommykeyapp.com/uploads/...` 形式であること

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)