### PR TITLE
fix: UX改善 — hover表示 + パスワード要件

### DIFF
--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -153,6 +153,9 @@
 						required
 						minlength={8}
 					/>
+					{#if mode === 'signup'}
+						<p class="text-xs text-muted-foreground">8文字以上、大文字・小文字・数字を含む</p>
+					{/if}
 					<Button type="submit" disabled={loading} class="w-full">
 						{loading ? '処理中...' : mode === 'login' ? 'ログイン' : 'サインアップ'}
 					</Button>

--- a/web/src/routes/rooms/[roomId]/+page.svelte
+++ b/web/src/routes/rooms/[roomId]/+page.svelte
@@ -427,7 +427,7 @@
 						{/if}
 					{/if}
 					{#if isOwnMessage(msg) && msg.messageType === 'TEXT' && editingId !== msg.id}
-						<div class="mt-1 flex gap-2">
+						<div class="mt-1 flex gap-2 opacity-0 transition group-hover:opacity-100">
 							<button onclick={() => handleEdit(msg)} class="text-[10px] text-muted-foreground/40 hover:text-muted-foreground">編集</button>
 							<button onclick={() => handleDeleteMessage(msg.id)} class="text-[10px] text-muted-foreground/40 hover:text-red-400">削除</button>
 						</div>


### PR DESCRIPTION
## Summary
- チャットルームの編集/削除ボタンをメッセージhover時のみ表示に変更（常時表示 → UIノイズ軽減）
- サインアップフォームにパスワード要件「8文字以上、大文字・小文字・数字を含む」を表示

## Test plan
- [x] `pnpm build` ビルド成功
- [ ] チャットルームでメッセージにホバーすると編集/削除ボタンが表示されること
- [ ] サインアップタブでパスワード要件テキストが表示されること

Closes #64
Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)