### PR TITLE
fix: CDのmanifest更新をPR経由に変更

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   AWS_REGION: ap-northeast-1
@@ -88,13 +89,23 @@ jobs:
           cd manifests/base
           kustomize edit set image chat-api=$ECR_REGISTRY/$ECR_REPOSITORY@$DIGEST
 
-      - name: Commit and push manifest update
+      - name: Create PR for manifest update
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add manifests/base/kustomization.yaml
-          git diff --staged --quiet || git commit -m "build: automatic update of chat"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          BRANCH="auto/update-manifest-$(git rev-parse --short HEAD)"
+          git checkout -b "$BRANCH"
+          git commit -m "build: automatic update of chat"
+          git push origin "$BRANCH"
+          gh pr create --title "build: automatic update of chat" --body "Automated manifest update by CD pipeline." --base main --head "$BRANCH"
+          gh pr merge "$BRANCH" --merge-queue
 
   deploy-web:
     needs: deploy-infra


### PR DESCRIPTION
## Summary
- CDワークフローの `deploy-api` ジョブが `git push` で直接 main に push していたのを、PR作成 + merge queue 経由に変更
- ブランチ保護ルール（merge queue必須）との競合を解消

fixes #83

## Test plan
- [ ] `api/` 配下の変更をマージしてCDが正常に動作することを確認
- [ ] `auto/update-manifest-*` ブランチでPRが作成され、merge queue に入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)