### PR TITLE
fix: CDワークフローのmergeフラグを修正

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -105,7 +105,7 @@ jobs:
           git commit -m "build: automatic update of chat"
           git push origin "$BRANCH"
           gh pr create --title "build: automatic update of chat" --body "Automated manifest update by CD pipeline." --base main --head "$BRANCH"
-          gh pr merge "$BRANCH" --merge-queue
+          gh pr merge "$BRANCH" --auto --delete-branch
 
   deploy-web:
     needs: deploy-infra


### PR DESCRIPTION
## Summary
- `gh pr merge --merge-queue` は存在しないフラグのため `--auto --delete-branch` に修正

## Test plan
- [ ] `api/` 配下の変更をマージしてCDが正常に動作し、manifest更新PRが自動マージされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)