### PR TITLE
fix: CDのmanifest更新ブランチ名の衝突を修正

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -100,7 +100,7 @@ jobs:
             echo "No changes to commit"
             exit 0
           fi
-          BRANCH="auto/update-manifest-$(git rev-parse --short HEAD)"
+          BRANCH="auto/update-manifest-$(date +%Y%m%d%H%M%S)"
           git checkout -b "$BRANCH"
           git commit -m "build: automatic update of chat"
           git push origin "$BRANCH"


### PR DESCRIPTION
## Summary
- ブランチ名に `git rev-parse --short HEAD` を使っていたため、リトライ時にブランチ名が衝突してpushが失敗していた
- タイムスタンプベースに変更して一意性を保証

## Test plan
- [ ] CDを実行してmanifest更新PRが正常に作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)