### PR TITLE
fix: CDのmanifest更新にGitHub Appトークンを使用

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 env:
   AWS_REGION: ap-northeast-1
@@ -89,9 +88,16 @@ jobs:
           cd manifests/base
           kustomize edit set image chat-api=$ECR_REGISTRY/$ECR_REPOSITORY@$DIGEST
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create PR for manifest update
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- GITHUB_TOKENで作成したPRはCIがトリガーされずmerge queueでマージできなかった
- GitHub App (`tommykey-cd-bot`) のトークンに切り替えて解決

fixes #83

## Test plan
- [ ] CDを実行してmanifest更新PRが作成され、CIがトリガーされ、merge queueで自動マージされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)