### PR TITLE
feat: chat/infraをK3s対応に修正

### DIFF
--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -62,10 +62,10 @@ resource "aws_cloudfront_distribution" "chat" {
     origin_access_control_id = aws_cloudfront_origin_access_control.uploads.id
   }
 
-  # ALB origin for API
+  # K3s Traefik origin for API
   origin {
-    domain_name = data.aws_lb.chat.dns_name
-    origin_id   = "alb-api"
+    domain_name = aws_route53_record.api_origin.fqdn
+    origin_id   = "k3s-api"
 
     custom_origin_config {
       http_port              = 80
@@ -100,7 +100,7 @@ resource "aws_cloudfront_distribution" "chat" {
     path_pattern             = "/api/*"
     allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods           = ["GET", "HEAD"]
-    target_origin_id         = "alb-api"
+    target_origin_id         = "k3s-api"
     viewer_protocol_policy   = "redirect-to-https"
     cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer.id
@@ -111,7 +111,7 @@ resource "aws_cloudfront_distribution" "chat" {
     path_pattern             = "/ws"
     allowed_methods          = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods           = ["GET", "HEAD"]
-    target_origin_id         = "alb-api"
+    target_origin_id         = "k3s-api"
     viewer_protocol_policy   = "redirect-to-https"
     cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer.id

--- a/infra/data.tf
+++ b/infra/data.tf
@@ -27,30 +27,21 @@ data "aws_subnets" "public" {
   }
 }
 
-data "aws_eks_cluster" "existing" {
-  name = var.eks_cluster_name
-}
-
-data "aws_eks_cluster_auth" "existing" {
-  name = var.eks_cluster_name
-}
-
 data "aws_caller_identity" "current" {}
 
-data "aws_lb" "chat" {
-  tags = {
-    "ingress.k8s.aws/stack" = "chat/chat-api"
+data "aws_instance" "k3s" {
+  filter {
+    name   = "tag:Name"
+    values = ["shared-k3s"]
+  }
+
+  filter {
+    name   = "instance-state-name"
+    values = ["running"]
   }
 }
 
-data "aws_security_groups" "eks_nodes" {
-  filter {
-    name   = "tag:kubernetes.io/cluster/${var.eks_cluster_name}"
-    values = ["owned"]
-  }
-
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.existing.id]
-  }
+data "aws_ssm_parameter" "k3s_kubeconfig" {
+  name            = "/shared/k3s/kubeconfig"
+  with_decryption = true
 }

--- a/infra/dns.tf
+++ b/infra/dns.tf
@@ -9,6 +9,15 @@ data "aws_acm_certificate" "wildcard" {
   statuses = ["ISSUED"]
 }
 
+# api-origin.tommykeyapp.com -> K3s EIP (CloudFront origin)
+resource "aws_route53_record" "api_origin" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "api-origin.tommykeyapp.com"
+  type    = "A"
+  ttl     = 300
+  records = [data.aws_instance.k3s.public_ip]
+}
+
 # chat.tommykeyapp.com -> CloudFront
 resource "aws_route53_record" "chat" {
   zone_id = data.aws_route53_zone.main.zone_id

--- a/infra/irsa.tf
+++ b/infra/irsa.tf
@@ -1,33 +1,3 @@
-locals {
-  oidc_provider_arn = replace(
-    data.aws_eks_cluster.existing.identity[0].oidc[0].issuer,
-    "https://",
-    ""
-  )
-}
-
-module "irsa_chat_api" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.0"
-
-  role_name = "${var.project}-api"
-
-  oidc_providers = {
-    main = {
-      provider_arn               = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_provider_arn}"
-      namespace_service_accounts = ["chat:chat-api"]
-    }
-  }
-
-  role_policy_arns = {
-    chat_api_access = aws_iam_policy.chat_api_access.arn
-  }
-
-  tags = {
-    Project = var.project
-  }
-}
-
 resource "aws_iam_policy" "chat_api_access" {
   name        = "${var.project}-api-access"
   description = "Policy for chat API to access S3, SQS, and SES"
@@ -72,4 +42,9 @@ resource "aws_iam_policy" "chat_api_access" {
   tags = {
     Project = var.project
   }
+}
+
+resource "aws_iam_role_policy_attachment" "k3s_chat_api" {
+  role       = var.k3s_iam_role_name
+  policy_arn = aws_iam_policy.chat_api_access.arn
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -53,9 +53,9 @@ output "frontend_bucket_name" {
   value       = aws_s3_bucket.frontend.bucket
 }
 
-output "api_role_arn" {
-  description = "IAM role ARN for chat API (IRSA)"
-  value       = module.irsa_chat_api.iam_role_arn
+output "k3s_iam_role_name" {
+  description = "K3s IAM role name with chat API access"
+  value       = var.k3s_iam_role_name
 }
 
 output "region" {

--- a/infra/security-groups.tf
+++ b/infra/security-groups.tf
@@ -1,8 +1,5 @@
 locals {
-  eks_security_group_ids = distinct(concat(
-    [data.aws_eks_cluster.existing.vpc_config[0].cluster_security_group_id],
-    data.aws_security_groups.eks_nodes.ids,
-  ))
+  k3s_security_group_ids = data.aws_instance.k3s.vpc_security_group_ids
 }
 
 resource "aws_security_group" "rds" {
@@ -11,11 +8,11 @@ resource "aws_security_group" "rds" {
   vpc_id      = data.aws_vpc.existing.id
 
   ingress {
-    description     = "PostgreSQL from EKS nodes"
+    description     = "PostgreSQL from K3s"
     from_port       = 5432
     to_port         = 5432
     protocol        = "tcp"
-    security_groups = local.eks_security_group_ids
+    security_groups = tolist(local.k3s_security_group_ids)
   }
 
   egress {
@@ -37,11 +34,11 @@ resource "aws_security_group" "redis" {
   vpc_id      = data.aws_vpc.existing.id
 
   ingress {
-    description     = "Redis from EKS nodes"
+    description     = "Redis from K3s"
     from_port       = 6379
     to_port         = 6379
     protocol        = "tcp"
-    security_groups = local.eks_security_group_ids
+    security_groups = tolist(local.k3s_security_group_ids)
   }
 
   egress {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -10,18 +10,17 @@ variable "project" {
   default     = "chat"
 }
 
-variable "eks_cluster_name" {
-  description = "Name of the existing EKS cluster"
-  type        = string
-  default     = "url-shortener-cluster"
-}
-
 variable "vpc_name" {
   description = "Name of the existing VPC"
   type        = string
-  default     = "url-shortener-vpc"
+  default     = "shared-vpc"
 }
 
+variable "k3s_iam_role_name" {
+  description = "IAM role name of the K3s instance profile"
+  type        = string
+  default     = "shared-k3s"
+}
 
 variable "db_username" {
   description = "Database master username"

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "~> 2.0"
-    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"
@@ -30,16 +26,9 @@ provider "aws" {
   region = "us-east-1"
 }
 
-provider "helm" {
-  kubernetes {
-    host                   = data.aws_eks_cluster.existing.endpoint
-    cluster_ca_certificate = base64decode(data.aws_eks_cluster.existing.certificate_authority[0].data)
-    token                  = data.aws_eks_cluster_auth.existing.token
-  }
-}
-
 provider "kubernetes" {
-  host                   = data.aws_eks_cluster.existing.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.existing.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.existing.token
+  host                   = yamldecode(data.aws_ssm_parameter.k3s_kubeconfig.value).clusters[0].cluster.server
+  cluster_ca_certificate = base64decode(yamldecode(data.aws_ssm_parameter.k3s_kubeconfig.value).clusters[0].cluster.certificate-authority-data)
+  client_certificate     = base64decode(yamldecode(data.aws_ssm_parameter.k3s_kubeconfig.value).users[0].user.client-certificate-data)
+  client_key             = base64decode(yamldecode(data.aws_ssm_parameter.k3s_kubeconfig.value).users[0].user.client-key-data)
 }


### PR DESCRIPTION
## Summary
- EKS/ALB data source → K3sインスタンス参照に変更
- IRSA module → EC2 Instance Profileへのポリシーアタッチに変更
- CloudFront ALBオリジン → K3s Traefik (api-origin.tommykeyapp.com)に変更
- セキュリティグループのEKS参照 → K3s SG参照に変更
- kubernetes providerをSSM kubeconfig経由に変更
- project名をsharedに更新