### PR TITLE
fix: CDのCloudFront/S3参照をSSM Parameter Store経由に変更

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -142,8 +142,14 @@ jobs:
           VITE_COGNITO_CLIENT_ID: 7vsovq6esg1am78jmk3diucc3q
         run: cd web && pnpm install --frozen-lockfile && pnpm build
 
+      - name: Get deployment parameters from SSM
+        id: params
+        run: |
+          echo "cloudfront_id=$(aws ssm get-parameter --name /chat/cloudfront-distribution-id --query 'Parameter.Value' --output text)" >> $GITHUB_OUTPUT
+          echo "frontend_bucket=$(aws ssm get-parameter --name /chat/frontend-bucket --query 'Parameter.Value' --output text)" >> $GITHUB_OUTPUT
+
       - name: Deploy to S3
-        run: aws s3 sync web/build/ s3://${{ secrets.FRONTEND_BUCKET }} --delete
+        run: aws s3 sync web/build/ s3://${{ steps.params.outputs.frontend_bucket }} --delete
 
       - name: Invalidate CloudFront cache
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+        run: aws cloudfront create-invalidation --distribution-id ${{ steps.params.outputs.cloudfront_id }} --paths "/*"

--- a/infra/ssm.tf
+++ b/infra/ssm.tf
@@ -1,0 +1,19 @@
+resource "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name  = "/chat/cloudfront-distribution-id"
+  type  = "String"
+  value = aws_cloudfront_distribution.chat.id
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_ssm_parameter" "frontend_bucket" {
+  name  = "/chat/frontend-bucket"
+  type  = "String"
+  value = aws_s3_bucket.frontend.bucket
+
+  tags = {
+    Project = var.project
+  }
+}


### PR DESCRIPTION
## Summary
- GitHub Secretsの手動管理をやめ、SSM Parameter Store経由に変更
- terraform applyで自動更新されるので、destroy → apply後もCDが正しく動く
- `CLOUDFRONT_DISTRIBUTION_ID` と `FRONTEND_BUCKET` のsecretsは不要になる

## 変更内容
- `infra/ssm.tf` 新規: CloudFront ID と S3 bucket名をSSMに保存
- `cd.yaml`: secretsの代わりにSSMから読み取り