### PR TITLE
fix: E2EテストのCognitoダミー値を有効な形式に修正

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,6 @@ jobs:
 
       - name: Build and run E2E tests
         env:
-          VITE_COGNITO_USER_POOL_ID: dummy
-          VITE_COGNITO_CLIENT_ID: dummy
+          VITE_COGNITO_USER_POOL_ID: ap-northeast-1_DummyPool
+          VITE_COGNITO_CLIENT_ID: dummyclientid0000000000000
         run: cd web && pnpm build && pnpm test:e2e


### PR DESCRIPTION
## Summary
- CIのE2Eテストで `VITE_COGNITO_USER_POOL_ID=dummy` としていたが、`amazon-cognito-identity-js` が `region_xxx` 形式を期待するため初期化時にエラー → ページが表示されず全テスト失敗していた
- `ap-northeast-1_DummyPool` 形式のダミー値に変更し、ビルド・E2Eテストが通ることを確認済み

## Test plan
- [x] ローカルでビルド成功確認
- [x] ローカルでE2E 8/8パス確認
- [ ] CIでE2Eパス確認