### PR TITLE
fix: CD の deploy-infra 条件を paths-filter で正しく判定

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,9 +18,24 @@ env:
   ECR_REPOSITORY: chat-api
 
 jobs:
-  deploy-infra:
+  detect-changes:
     runs-on: ubuntu-latest
-    if: contains(github.event.head_commit.modified, 'infra/') || github.event_name == 'workflow_dispatch'
+    outputs:
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            infra:
+              - 'infra/**'
+              - 'lambda/**'
+
+  deploy-infra:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 
@@ -58,7 +73,7 @@ jobs:
           terraform apply tfplan
 
   deploy-api:
-    needs: deploy-infra
+    needs: [detect-changes, deploy-infra]
     if: always() && (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -118,7 +133,7 @@ jobs:
           gh pr merge "$BRANCH" --auto
 
   deploy-web:
-    needs: deploy-infra
+    needs: [detect-changes, deploy-infra]
     if: always() && (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- \`github.event.head_commit.modified\` が 2019 年廃止済みで push payload に存在せず、\`contains()\` が常に false になり \`deploy-infra\` が push イベントで全スキップされていた
- \`dorny/paths-filter@v3\` を使う前段 \`detect-changes\` ジョブを追加し、\`infra/**\` / \`lambda/**\` の変更検出結果を \`deploy-infra\` の if に使う
- \`workflow_dispatch\` は手動フォールバックとして残す

## Context
過去 50 件の CD 実行で \`deploy-infra\` の成功は 2026-04-02 の手動実行 1 回のみ。#95, #100, #104, #106, #111 の infra 変更が apply 未反映の可能性が高い。

fixes #113

## Test plan
- [ ] この PR 自体は \`.github/workflows/**\` のみの変更で \`paths:\` トリガー対象外のため CD は走らない想定
- [ ] マージ後、次に infra/ を触る PR で deploy-infra が success することを確認
- [ ] 必要に応じて workflow_dispatch で現状 diff を plan ログから確認