### PR TITLE
fix: Lambda thumbnail のパッケージングを archive_file ベースに移行

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -55,11 +55,10 @@ jobs:
           cache: pnpm
           cache-dependency-path: lambda/thumbnail/pnpm-lock.yaml
 
-      - name: Build Lambda thumbnail
+      - name: Install Lambda thumbnail deps
         run: |
           cd lambda/thumbnail
           pnpm install --frozen-lockfile --prod
-          zip -r ../../infra/lambda-thumbnail.zip .
 
       - uses: hashicorp/setup-terraform@v3
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ infra/.terraform/
 infra/*.tfstate
 infra/*.tfstate.backup
 infra/*.tfvars
+infra/lambda-thumbnail.zip
 
 # Web (SvelteKit)
 web/node_modules/

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = ">= 4.0.0, ~> 5.0"
@@ -65,24 +85,23 @@ provider "registry.terraform.io/hashicorp/tls" {
 }
 
 provider "registry.terraform.io/integrations/github" {
-  version     = "6.11.1"
+  version     = "6.12.0"
   constraints = "~> 6.0"
   hashes = [
-    "h1:Hqvebe3Zc19DxRCHHLIByBvxCm+WJqGyAyYCbJDuHGE=",
-    "zh:0a5262b033a30d8a77ebf844dc3afd7e726d5f53ac1c9d4072cf9157820d1f73",
-    "zh:437236181326f92d1a7c56985b2ac3223efd73f75c528323b90f4b7d1b781090",
-    "zh:49a12c14d1d3a143a124ba81f15fbf18714af90752c993698c76e84fa85da004",
-    "zh:61eaf17b559a26ca14deb597375a6678d054d739e8b81c586ef1d0391c307916",
-    "zh:7f3f1e2c36f4787ca9a5aeb5317b8c3f6cc652368d1f8f00fb80f404109d4db1",
-    "zh:85a232f2e96e5adafa2676f38a96b8cc074e96f715caf6ee1d169431174897d2",
-    "zh:979d005af2a9003d887413195948c899e9f5aba4a79cce1eed40f3ba50301af1",
-    "zh:b8c8cd3254504d2184d2b2233ad41b5fdfda91a36fc864926cbc5c7eee1bfea3",
-    "zh:d00959e62930fb75d2b97c1d66ab0143120541d5a1b3f26d3551f24cb0361f83",
-    "zh:d0b544eed171c7563387fe87f0af3d238bb3804798159b4d0453c97927237daf",
-    "zh:ecfa19b1219aa55b1ece98d8cff5b1494dc0387329c8ae0d8f762ec3871fb75d",
-    "zh:f2c99825f38c92ac599ad36b9d093ea0c0d790fd0c02e861789e14735a605f86",
-    "zh:f33b5abe14ad5fb9978da5dbd3bc6989f69766150d4b30ed283a2c281871eda3",
-    "zh:f6c2fe9dd958c554170dc0c35ca41b60fcc6253304cde0b9941c5c872b18ac54",
+    "h1:Ggo6UCbR2gIuSiH6P3X9OWhd7Cgz+4kz/mjOn/AhF2E=",
+    "zh:0748f95426c7ef9f2a4759dc5b7727796cfdf4358f9fcf0db4c7b26c476708c3",
+    "zh:074bb3ba19fe340a5d3c220c9cdbb98344000566a5b201fbf95b57d7f8f99e70",
+    "zh:0c930ef5e64c15318251605c75b5417fdc20cf86e1b3eed107d2a07c76504125",
+    "zh:1a0ba200992cc4fead56861acfad9c53d5c012fcd2b386d797d86aa6828984f8",
+    "zh:447adaa0b2e314643517ef4312be0a5381356891bffd9d09fe9749006d08a77d",
+    "zh:47b37afbd73240f26f211a92c46950cb01d44b6f0090279b5611b5f849c98f2e",
+    "zh:53ac39084a384b30d986e9dbbdb3c8fb584ab6962ea7dfdfdcfb8a0d4fb3e7cb",
+    "zh:5a28e6eae849c30308a2b76dc7504051eb57e872aefe4c82596343466be5087d",
+    "zh:6fe48c6da41755d16e6f91c6937908e074c53f16f3b27a2c64e396ad19ed1337",
+    "zh:a2e02cdecb7c411274df1785d07ddca350254cacb5702d793517efe8744b9891",
+    "zh:b393080029ec1e44a9f4fa5c19388ec54c4d811666b325fddf71c4b8b04d47af",
+    "zh:be2d0a4518259238933fc592fedda2758ca6a31996a0bbc55fb7f694d07a2de0",
+    "zh:def6ef3bec386e46019618b3760a647199a467abd0302f8f8705417856756c6e",
     "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
   ]
 }

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -49,15 +49,23 @@ resource "aws_iam_role_policy" "thumbnail_lambda" {
   })
 }
 
+data "archive_file" "thumbnail" {
+  type             = "zip"
+  source_dir       = "${path.module}/../lambda/thumbnail"
+  output_path      = "${path.module}/lambda-thumbnail.zip"
+  output_file_mode = "0644"
+}
+
 resource "aws_lambda_function" "thumbnail" {
-  filename         = "${path.module}/lambda-thumbnail.zip"
+  filename         = data.archive_file.thumbnail.output_path
   function_name    = "${var.project}-thumbnail"
   role             = aws_iam_role.thumbnail_lambda.arn
   handler          = "index.handler"
   runtime          = "nodejs22.x"
+  architectures    = ["x86_64"]
   timeout          = 30
   memory_size      = 512
-  source_code_hash = filebase64sha256("${path.module}/lambda-thumbnail.zip")
+  source_code_hash = data.archive_file.thumbnail.output_base64sha256
 
   tags = {
     Project = var.project

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"

--- a/lambda/thumbnail/.npmrc
+++ b/lambda/thumbnail/.npmrc
@@ -1,1 +1,4 @@
 node-linker=hoisted
+supported-architectures.os[]=linux
+supported-architectures.cpu[]=x64
+supported-architectures.libc[]=glibc


### PR DESCRIPTION
## Summary

`infra/lambda.tf` が `filebase64sha256("${path.module}/lambda-thumbnail.zip")` でローカル zip に直接依存しており、CD でしか zip を作っていないため **ローカルで `terraform plan` / `terraform destroy` が実行できない**問題を、HashiCorp 公式推奨の `data "archive_file"` パターンに移行することで解決する。

## Changes

- `infra/versions.tf`: `hashicorp/archive ~> 2.4` provider 追加
- `infra/lambda.tf`: `data "archive_file"` で zip を plan 時に生成、`architectures = ["x86_64"]` を明示
- `lambda/thumbnail/.npmrc`: `supported-architectures.{os,cpu,libc}` で sharp の native binary を Linux x64 glibc 固定
- `.github/workflows/cd.yaml`: 手動 zip 生成ステップを削除（Terraform 側でやる）
- `.gitignore`: `infra/lambda-thumbnail.zip` を追加（generated artifact）
- `infra/.terraform.lock.hcl`: archive provider 追加に伴い更新

## Why

- ローカルでも CI でも同じ方法で zip が作られる（ローカル plan/destroy が動くように）
- archive_file は中身ベースで hash を計算（タイムスタンプを `2049-01-01` に正規化）するので `source_code_hash` が安定 → 無駄な Lambda 再デプロイを防止
- sharp の native binary が install 環境に依存しない（macOS で `pnpm install` しても Lambda 用バイナリが入る）

## Verification

ローカルで実施済み:

- [x] `terraform init -upgrade` で `hashicorp/archive v2.7.1` 取得成功
- [x] `terraform plan` 通過（`source_code_hash` のみ更新、`Plan: 0 to add, 1 to change, 0 to destroy.`）
- [x] zip が `infra/lambda-thumbnail.zip` (11MB, 3712 files) に自動生成されること確認
- [x] zip 内に `node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node` が含まれること確認
- [x] zip 内のタイムスタンプが `2049-01-01` 固定（archive_file の reproducibility 機能）

CI / 本番マージ後の確認:

- [ ] CD `deploy-infra` job が緑（zip ステップを削った状態で）
- [ ] S3 に画像アップロード → `_thumb` サフィックス付きサムネイルが生成される

Fixes #119