### PR TITLE
ci: PR で terraform plan を走らせる check を追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,3 +66,35 @@ jobs:
           VITE_COGNITO_USER_POOL_ID: ap-northeast-1_DummyPool
           VITE_COGNITO_CLIENT_ID: dummyclientid0000000000000
         run: cd web && pnpm build && pnpm test:e2e
+
+  terraform-plan:
+    runs-on: ubuntu-latest
+    env:
+      TF_VAR_github_token: ${{ secrets.GH_PAT }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: lambda/thumbnail/pnpm-lock.yaml
+
+      - name: Install Lambda thumbnail deps
+        run: |
+          cd lambda/thumbnail
+          pnpm install --frozen-lockfile --prod
+
+      - uses: tommykey-apps/.github/.github/actions/terraform-plan@v1
+        with:
+          working-directory: infra


### PR DESCRIPTION
## Summary

`tommykey-apps/.github` (PR #122 で作成) の `terraform-plan` composite action (v1) を chat の CI に組み込む。これで PR 時点で \`terraform plan\` が走り、\`infra/\` の問題が main マージ前に検知できる。

## Changes

- \`.github/workflows/ci.yaml\` に \`terraform-plan\` job を追加
  - AWS credentials は既存 secrets を流用
  - \`TF_VAR_github_token\` を \`secrets.GH_PAT\` から
  - \`archive_file\` が node_modules 込みで zip するため、composite action 呼び出し前に \`pnpm install --frozen-lockfile --prod\` を実行

## Why

PR #120 で発覚した \`filebase64sha256("...zip")\` のローカル plan 失敗は、PR 時点で plan が走っていれば早期検知できた事例。今後の同種事故を防止する。

## Test plan

- [x] composite action の v1 タグ作成済み (https://github.com/tommykey-apps/.github/releases/tag/v1.0.0)
- [ ] この PR で \`terraform-plan / plan\` job が緑になる
- [ ] 別ブランチで \`infra/lambda.tf\` をわざと壊して PR を出して、CI が **赤くなる** ことを確認（マージしない、確認後ブランチ削除）

Fixes #123