### PR TITLE
fix: chat-api-secret と imagePullSecrets を IaC 化（K3s 再構築耐性）

### DIFF
--- a/infra/k8s-secrets.tf
+++ b/infra/k8s-secrets.tf
@@ -1,0 +1,10 @@
+resource "kubernetes_secret" "chat_api_secret" {
+  metadata {
+    name      = "chat-api-secret"
+    namespace = "chat"
+  }
+
+  data = {
+    "db-password" = var.db_password
+  }
+}

--- a/manifests/base/serviceaccount.yaml
+++ b/manifests/base/serviceaccount.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: chat-api
   namespace: chat
+imagePullSecrets:
+  - name: ecr-cred


### PR DESCRIPTION
## Summary

K3s 再構築時に chat-api が壊れる問題（#127）を IaC で根本対処する。

## Background

PR #124 (terraform-plan check 導入) のマージで infra-shared CD が走り、AMI ドリフトに起因して K3s インスタンスが destroy + recreate された。新インスタンス上で chat-api Pod は:

- \`chat-api-secret\` (DB password) が IaC 外管理で見当たらず → \`secret not found\`
- \`imagePullSecrets\` が manifest に未記載 → ECR pull 認証エラー (\`ImagePullBackOff\`)

ホットフィックスで API は復旧済みだが、IaC ギャップを閉じないと次の K3s 再構築でも再発する。

## Changes

- \`infra/k8s-secrets.tf\` (新規): \`kubernetes_secret \"chat_api_secret\"\` 追加
  - 既存の \`infra/argocd.tf\` / \`infra/cloudfront-key.tf\` と同じ \`kubernetes_secret\` パターン
  - \`var.db_password\` を data に渡すことで RDS と Secret を同 source of truth に
- \`manifests/base/serviceaccount.yaml\`: \`imagePullSecrets: [ecr-cred]\` を追加
  - chat-api Deployment は \`serviceAccountName: chat-api\` を参照しているため SA 経由で全 Pod に伝播

## Why

- ローカル実行不要、CD で IaC が完結
- K3s 単一インスタンスが何かの理由で再作成されても chat-api が自動復旧する
- imagePullSecrets を Deployment 直書きでなく SA に持たせることで DRY

## Test plan

- [x] terraform-plan check 緑（PR の CI で plan が通る）
- [ ] Merge 前に手動 \`chat-api-secret\` を削除（terraform create のため）
- [ ] Merge 後 CD deploy-infra で kubernetes_secret 作成確認
- [ ] ArgoCD sync で SA に imagePullSecrets が反映、chat-api Pod 再起動 → Running
- [ ] \`curl -sIk https://api-origin.tommykeyapp.com/actuator/health\` が \`200\`

## スコープ外（別 issue 候補）

- \`db_password\` ハードコード default の削除 + GitHub secret 経由化
- \`api-origin.tommykeyapp.com\` の TLS cert 自動発行 (cert-manager + Ingress annotation)

Fixes #127