### PR TITLE
fix: db_password ハードコード default 削除 + rotation

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -65,6 +65,7 @@ jobs:
       - name: Terraform Plan
         env:
           TF_VAR_github_token: ${{ secrets.GH_PAT }}
+          TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
         run: |
           cd infra
           terraform init
@@ -73,6 +74,7 @@ jobs:
       - name: Terraform Apply
         env:
           TF_VAR_github_token: ${{ secrets.GH_PAT }}
+          TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
         run: |
           cd infra
           terraform apply tfplan

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TF_VAR_github_token: ${{ secrets.GH_PAT }}
+      TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
 

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -23,6 +23,7 @@ resource "aws_db_instance" "chat" {
 
   skip_final_snapshot = true
   multi_az            = false
+  apply_immediately   = true
 
   tags = {
     Project = var.project

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -38,5 +38,4 @@ variable "db_password" {
   description = "Database master password"
   type        = string
   sensitive   = true
-  default     = "chatpassword123"
 }


### PR DESCRIPTION
## Summary

\`chat/infra/variables.tf\` の \`db_password\` ハードコード default (\`\"chatpassword123\"\`) を削除し、GitHub Secret 経由で渡す方式に変更。同時に rotation も実施。

## Context

\`db_password\` は public repo の git history に平文で残存していた。改善案として:

- variables.tf から default を削除 (required 化)
- chat repo の GitHub Secret に \`DB_PASSWORD\` を新規追加（事前に ランダム値を設定済）
- CD / CI の terraform 実行 env で \`TF_VAR_db_password\` として渡す
- rds.tf に \`apply_immediately = true\` を追加して password 変更が即時反映されるようにする

\`kubernetes_secret.chat_api_secret\` は \`var.db_password\` を参照しているので、CD apply 時に RDS と K8s Secret が同期して更新される。

## Changes

- \`infra/variables.tf\`: \`db_password\` の default 削除
- \`infra/rds.tf\`: \`aws_db_instance.chat\` に \`apply_immediately = true\` 追加
- \`.github/workflows/cd.yaml\`: deploy-infra (Plan/Apply) の env に \`TF_VAR_db_password: \${{ secrets.DB_PASSWORD }}\` 追加
- \`.github/workflows/ci.yaml\`: terraform-plan job の env に同上

## Why

- public repo に DB password が hardcoded で残っているのを解消
- 将来 rotation したくなったら GitHub Secret 更新 → PR で apply するだけで完結

## Test plan

- [ ] \`terraform-plan\` check 緑（GitHub Secret \`DB_PASSWORD\` から TF_VAR が渡って plan 通る）
- [ ] CI の plan output で確認:
  - \`aws_db_instance.chat\` の password 変更
  - \`kubernetes_secret.chat_api_secret\` の data 変更
- [ ] Merge 後 CD deploy-infra 緑
- [ ] Merge 後 \`kubectl rollout restart deploy/chat-api -n chat\` で Pod 再起動
- [ ] chat-api が新 password で RDS 接続成功

## ダウンタイム

merge 後 \`kubectl rollout restart\` 実行までの間、約 30 秒〜1 分間 chat-api が DB 接続失敗する想定。portfolio スケールなので許容。

Fixes #130