### PR TITLE
ci: shared infra が無い時は terraform-plan を skip

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,21 +80,37 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
 
+      - name: Check shared infra exists
+        id: shared
+        run: |
+          VPC=$(aws ec2 describe-vpcs --filters Name=tag:Name,Values=shared-vpc \
+                  --query 'Vpcs[0].VpcId' --output text 2>/dev/null || true)
+          if [ -n "$VPC" ] && [ "$VPC" != "None" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::shared-vpc not found, skipping terraform plan (chat の data source は infra-shared に依存しているため)"
+          fi
+
       - uses: pnpm/action-setup@v4
+        if: steps.shared.outputs.exists == 'true'
         with:
           version: 10
 
       - uses: actions/setup-node@v4
+        if: steps.shared.outputs.exists == 'true'
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: lambda/thumbnail/pnpm-lock.yaml
 
       - name: Install Lambda thumbnail deps
+        if: steps.shared.outputs.exists == 'true'
         run: |
           cd lambda/thumbnail
           pnpm install --frozen-lockfile --prod
 
       - uses: tommykey-apps/.github/.github/actions/terraform-plan@v1
+        if: steps.shared.outputs.exists == 'true'
         with:
           working-directory: infra


### PR DESCRIPTION
## Summary

\`chat/infra/data.tf\` は infra-shared が提供する VPC / K3s instance / SSM kubeconfig を data source で参照しているため、**infra-shared が destroy された状態だと plan が解決エラーで fail し続ける**。

shared-vpc の存在を CI ジョブの最初にチェックし、無ければ terraform-plan 関連の step を **全部 skip して job 全体を success 扱い**で終わらせるようにする。

## Changes

- \`.github/workflows/ci.yaml\`: terraform-plan job に \`Check shared infra exists\` step 追加、後続 step に \`if: steps.shared.outputs.exists == 'true'\` を付ける
  - shared-vpc あり → 従来通り plan 実行
  - shared-vpc 無し → 各 step skip、job success
  - shared infra 立て直したら無条件で plan 実行に戻る（手動切り替え不要）

## Why

chat repo に出すあらゆる PR の terraform-plan check が、infra-shared 不在時に塞がる問題を解消。

## Test plan

- [ ] このPRで CI が緑（現在 shared-vpc 不在 → step skip で job success の想定）
- [ ] 将来 infra-shared を再 apply した後の PR では skip せず plan 実行されること

Fixes #133